### PR TITLE
Updated URLs for gwdetchar organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ See [the documentation](https://ldas-jobs.ligo.caltech.edu/~duncan.macleod/hveto
 
 ## Project status
 
-[![Build Status](https://travis-ci.org/hveto/hveto.svg?branch=master)](https://travis-ci.org/hveto/hveto)  
-[![Coverage Status](https://coveralls.io/repos/github/hveto/hveto/badge.svg?branch=master)](https://coveralls.io/github/hveto/hveto?branch=master)
+[![Build Status](https://travis-ci.com/gwdetchar/hveto.svg?branch=master)](https://travis-ci.com/gwdetchar/hveto)  
+[![Coverage Status](https://coveralls.io/repos/github/gwdetchar/hveto/badge.svg?branch=master)](https://coveralls.io/github/gwdetchar/hveto?branch=master)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,11 +14,11 @@ For full details see `Smith et al. (Classical and Quantum Gravity, 2011) <https:
 Installing Hveto
 ----------------
 
-The easiest method to install hveto is using `pip <https://pip.pypa.io/en/stable/>`_ directly from the `GitHub repository <https://github.com/hveto/hveto.git>`_:
+The easiest method to install hveto is using `pip <https://pip.pypa.io/en/stable/>`_ directly from the `GitHub repository <https://github.com/gwdetchar/hveto.git>`_:
 
 .. code-block:: bash
 
-   $ pip install git+https://github.com/hveto/hveto.git
+   $ pip install git+https://github.com/gwdetchar/hveto.git
 
 How to run Hveto
 ----------------

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -471,7 +471,7 @@ def write_footer(about=None, date=None):
         date = datetime.datetime.now().replace(second=0, microsecond=0)
     version = get_versions()['version']
     commit = get_versions()['full-revisionid']
-    url = 'https://github.com/hveto/hveto/tree/%s' % commit
+    url = 'https://github.com/gwdetchar/hveto/tree/%s' % commit
     hlink = markup.oneliner.a('Hveto version %s' % version, href=url,
                               target='_blank')
     page.p('Page generated using %s by %s at %s'

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -64,7 +64,7 @@ HTML_INIT = """<!DOCTYPE HTML>
 
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
-<p>Page generated using <a href="https://github.com/hveto/hveto/tree/%s" target="_blank">Hveto version %s</a> by {user} at {date}</p>
+<p>Page generated using <a href="https://github.com/gwdetchar/hveto/tree/%s" target="_blank">Hveto version %s</a> by {user} at {date}</p>
 </div>
 </footer>""" % (COMMIT, VERSION)
 


### PR DESCRIPTION
This PR updates any instances of `hveto/hveto` to `gwdetchar/hveto` to account for the repository transfer.