### PR TITLE
Require lscsoft-glue >= 1.60.0

### DIFF
--- a/hveto/core.py
+++ b/hveto/core.py
@@ -304,7 +304,7 @@ def veto(table, segmentlist):
     ----------
     table : `numpy.recarray`
         the table of event triggers to veto
-    segmentlist : `~glue.segments.segmentlist`
+    segmentlist : `~ligo.segments.segmentlist`
         the list of veto segments to use
 
     Returns
@@ -347,7 +347,7 @@ def veto_all(auxiliary, segmentlist):
     ----------
     auxiliary : `dict` of `numpy.recarray`
         a `dict` of event arrays to veto
-    segmentlist : `~glue.segments.segmentlist`
+    segmentlist : `~ligo.segments.segmentlist`
         the list of veto segments to use
 
     Returns

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -54,7 +54,7 @@ def find_trigger_files(channel, etg, segments, **kwargs):
     etg : `str`
         name of event trigger generator to find
 
-    segments : :class:`~glue.segments.segmentlist`
+    segments : :class:`~ligo.segments.segmentlist`
         list of segments to find
 
     **kwargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gitpython
 jinja2
 pykerberos
 gwtrigfind
-lscsoft-glue
+lscsoft-glue >= 1.60.0
 dqsegdb
 gwpy >= 0.12.0
 git+https://github.com/ligovirgo/gwdetchar.git

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'numpy',
     'matplotlib',
     'scipy',
-    'lscsoft-glue',
+    'lscsoft-glue >= 1.60.0',
     'dqsegdb',
     'gwpy >= 0.12.0',
     'lxml',


### PR DESCRIPTION
This PR formally requires `lscsoft-glue >= 1.60.0`.

This fixes #88.