### PR TITLE
Use gwdetchar-omega for omega scans

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -814,20 +814,27 @@ if args.omega_scans:
         [t['time'] for r in rounds for t in r.scans]))))
     logger.debug("Identified %d times for omega scan" % len(omegatimes))
     newtimes = [t for t in omegatimes if not
-                utils.omega_scan_complete(os.path.join(omegadir, str(t)))]
-    logger.debug("%d scans already complete, %d remaining"
+                os.path.exists(os.path.join(omegadir, str(t)))]
+    logger.debug("%d scans already complete or in progress, %d remaining"
                  % (len(omegatimes) - len(newtimes), len(newtimes)))
-    logger.info('Creating workflow for omega scans...')
-    batch = [args.wdq_batch] + newtimes + [
-        '--output-dir', omegadir,
-        '--ifo', ifo,
-    ]
-    logger.debug(batch)
-    proc = subprocess.Popen(batch)
-    out, err = proc.communicate()
-    if proc.returncode:
-        raise subprocess.CalledProcessError(proc.returncode, ' '.join(batch))
-    dagfile = os.path.join(omegadir, 'condor', 'wdq-batch.dag')
+    if len(newtimes) > 0:
+        logger.info('Creating workflow for omega scans...')
+        batch = [args.wdq_batch] + newtimes + [
+            '--wpipeline', 'gwdetchar-omega',
+            '--ignore-state-flags',
+            '--output-dir', omegadir,
+            '--ifo', ifo,
+            '--condor-timeout', str(24)
+        ]
+        logger.debug(batch)
+        proc = subprocess.Popen(batch)
+        out, err = proc.communicate()
+        if proc.returncode:
+            raise subprocess.CalledProcessError(
+                proc.returncode, ' '.join(batch))
+        dagfile = os.path.join(omegadir, 'condor', 'wdq-batch.dag')
+    else:
+        logger.debug('Skipping omega scans')
 
 # -- write HTML and finish
 

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -656,8 +656,8 @@ def write_round(round):
             for c, tag in zip([round.primary, round.winner.name],
                               ['Primary', 'Auxiliary']):
                 caption = 'Omega scan of %s at %s' % (c, t['time'])
-                png = ('./scans/%s/%s_%s_1.00_spectrogram_whitened.png'
-                       % (t['time'], t['time'], c))
+                png = ('./scans/%s/plots/%s-qscan_whitened-1.png'
+                       % (t['time'], c.replace('-', '_').replace(':', '-')))
                 page.a('[%s]' % tag[0].lower(), class_='fancybox',
                        href=png, title=caption,
                        **{'data-fancybox-group': 'omega-preview'})

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -45,36 +45,3 @@ def channel_groups(channellist, ngroups):
     n = int(ceil(len(channellist) / ngroups))
     for i in range(0, len(channellist), n):
         yield channellist[i:i+n]
-
-
-def omega_scan_complete(scandir):
-    """Determine whether an omega scan was completed in the given directory
-
-    Parameters
-    ----------
-    scandir : `str`
-        output directory for a single omega scan
-
-    Returns
-    -------
-    complete : `bool`
-        `True` if the scan is considered complete, otherwise `False`
-
-    Notes
-    -----
-    The test is whether the final line of the `log.txt` file in the `scandir`
-    starts with 'finished on'.
-    """
-    logfile = os.path.join(scandir, 'log.txt')
-    try:
-        with open(logfile) as f:
-            f.seek(-2, 2)
-            while f.read(1) != b'\n':
-                f.seek(-2, 1)
-            line = f.readline()
-    except IOError:
-        return False
-    else:
-        if line.startswith('finished on '):
-            return True
-    return False


### PR DESCRIPTION
This PR changes `bin/hveto` so that it uses the new `gwdetchar-omega` tool to create Omega scans. At runtime, since `hveto` already handles state flag requirements, `gwdetchar-omega` will be invoked with the `--ignore-state-flags` option. The option `--condor-timeout 24` will also be passed to prevent Omega scan jobs from idling.

Since the new code doesn't write a `log.txt` file, and since prior scans may still be in progress the next time `hveto` runs, this PR also changes the condition for launching Omega scans to a check of whether the expected output directory exists.

Note, this PR should not be merged until at least gwdetchar/gwdetchar#179 is merged.

cc @jrsmith02, @duncanmmacleod, @areeda 