### PR TITLE
Read DEFAULT_SEGMENT_SERVER from environment

### DIFF
--- a/hveto/config.py
+++ b/hveto/config.py
@@ -204,10 +204,13 @@ Module API
 ==========
 """
 
+import os
 try:
     import configparser
 except ImportError:  # python 2.x
     import ConfigParser as configparser
+
+from .segments import DEFAULT_SEGMENT_SERVER
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Joshua Smith <joshua.smith@ligo.org>'
@@ -221,7 +224,7 @@ class HvetoConfigParser(configparser.ConfigParser):
             'minimum-significance': 5,
         },
         'segments': {
-            'url': 'https://segments.ligo.org',
+            'url': DEFAULT_SEGMENT_SERVER,
             'analysis-flag': '%(IFO)s:DMT-ANALYSIS_READY:1',
             'padding': (0, 0),
         },

--- a/hveto/segments.py
+++ b/hveto/segments.py
@@ -21,6 +21,7 @@
 
 from __future__ import print_function
 
+import os
 import os.path
 from functools import wraps
 from urlparse import urlparse
@@ -30,6 +31,9 @@ from gwpy.segments import (DataQualityFlag, DataQualityDict)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Joshua Smith <joshua.smith@ligo.org>'
+
+DEFAULT_SEGMENT_SERVER = os.getenv('DEFAULT_SEGMENT_SERVER',
+                                   'https://segments.ligo.org')
 
 
 def integer_segments(f):
@@ -41,7 +45,7 @@ def integer_segments(f):
 
 
 @integer_segments
-def query(flag, start, end, url='https://segments.ligo.org'):
+def query(flag, start, end, url=DEFAULT_SEGMENT_SERVER):
     """Query a segment database for active segments associated with a flag
     """
     return DataQualityFlag.query(flag, start, end, url=url)


### PR DESCRIPTION
This PR updates `hveto.segments` to pull the default DQSEGDB host from the `DEFAULT_SEGMENT_SERVER` environment variable (backing up to `https://segments.ligo.org`). This should allow simpler reconfiguration of the relevant host, mainly useful during maintenance periods.