### PR TITLE
Refactored test suite to use pytest instead of unittest

### DIFF
--- a/hveto/tests/__init__.py
+++ b/hveto/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Joshua Smith (2016-)
+# Copyright (C) Joshua Smith (2018-)
 #
 # This file is part of the hveto python package.
 #
@@ -16,12 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with hveto.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Common things for hveto test suite
+"""Test for Heto
 """
-
-import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest

--- a/hveto/tests/test_core.py
+++ b/hveto/tests/test_core.py
@@ -16,23 +16,28 @@
 # You should have received a copy of the GNU General Public License
 # along with hveto.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for `hveto.core`
+"""Tests for :mod:`hveto.core`
 """
 
-from hveto import core
+import pytest
 
-from common import unittest
-
-
-class HvetoRoundTestCase(unittest.TestCase):
-    def test_init(self):
-        r = core.HvetoRound(1, 'X1:PRIMARY')
-        self.assertEqual(r.n, 1)
-        self.assertEqual(r.primary, 'X1:PRIMARY')
+from .. import core
 
 
-class CoreTestCase(unittest.TestCase):
-    def test_significance(self):
-        self.assertAlmostEqual(core.significance(1, 1), 0.19920008462778135)
-        self.assertAlmostEqual(core.significance(100, 10), 62.26771967596927)
-        self.assertEqual(core.significance(1, 100), 0.0)
+def test_create_round():
+    """Test creation of a `hveto.core.HvetoRound` object
+    """
+    r = core.HvetoRound(1, 'X1:PRIMARY')
+    assert r.n == 1
+    assert r.primary == 'X1:PRIMARY'
+
+
+@pytest.mark.parametrize('n, mu, sig', [
+    (1, 1, 0.19920008462778135),
+    (100, 10, 62.26771967596927),
+    (1, 100, 0.0),
+])
+def test_significance(n, mu, sig):
+    """Test :func:`hveto.core.significance`
+    """
+    assert core.significance(n, mu) == pytest.approx(sig)

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -19,48 +19,40 @@
 """Tests for `hveto.plot`
 """
 
-import os
 import tempfile
+
+import pytest
 
 from matplotlib import use
 use('agg')
 
 from numpy import random
 
-from hveto import plot
-
-from common import unittest
+from .. import plot
 
 
-class PlotTestCase(unittest.TestCase):
-    def setUp(self):
-        self.tempfileid, self.tempfile = tempfile.mkstemp(suffix='.png')
+@pytest.mark.parametrize('num', (10, 50, 200))
+def test_drop_plot(num):
+    random.seed(0)
+    # this test just makes sure the drop plot code runs end-to-end
+    channels = ['X1:TEST-%d' % i for i in range(num)]
+    old = dict(zip(channels, random.normal(size=num)))
+    new = dict(zip(channels, random.normal(size=num)))
+    with tempfile.NamedTemporaryFile(suffix='.png') as png:
+        plot.significance_drop(png.name, old, new)
 
-    def tearDown(self):
-        if os.path.isfile(self.tempfile):
-            os.remove(self.tempfile)
+    with tempfile.NamedTemporaryFile(suffix='.svg') as svg:
+        plot.significance_drop(svg.name, old, new)
 
-    def test_drop_plot(self):
-        # this test just makes sure the drop plot code runs end-to-end
-        for x in [10, 50, 200]:
-            channels = ['X1:TEST-%d' % i for i in range(x)]
-            old = dict(zip(channels, random.normal(size=x)))
-            new = dict(zip(channels, random.normal(size=x)))
-            plot.significance_drop(self.tempfile, old, new)
-            svg = self.tempfile.replace('.png', '.svg')
-            try:
-                plot.significance_drop(svg, old, new)
-            finally:
-                if os.path.isfile(svg):
-                    os.remove(svg)
 
-    def test_fancy_plot(self):
-        # create a dummy FancyPlot instance
-        test = plot.FancyPlot('test.png')
-        assert test.img is 'test.png'
-        assert test.caption is 'test.png'
-        # check that its properties are unchanged when the argument
-        # to FancyPlot() is also a FancyPlot instance
-        test = plot.FancyPlot(test)
-        assert test.img is 'test.png'
-        assert test.caption is 'test.png'
+def test_fancy_plot():
+    # create a dummy FancyPlot instance
+    test = plot.FancyPlot('test.png')
+    assert test.img is 'test.png'
+    assert test.caption is 'test.png'
+
+    # check that its properties are unchanged when the argument
+    # to FancyPlot() is also a FancyPlot instance
+    test = plot.FancyPlot(test)
+    assert test.img is 'test.png'
+    assert test.caption is 'test.png'

--- a/hveto/tests/test_segments.py
+++ b/hveto/tests/test_segments.py
@@ -21,11 +21,11 @@
 
 from tempfile import NamedTemporaryFile
 
+import pytest
+
 from gwpy.segments import (Segment, SegmentList)
 
-from hveto import segments
-
-from common import unittest
+from .. import segments
 
 TEST_SEGMENTS = SegmentList([
     Segment(0.1, 1.234567),
@@ -35,11 +35,10 @@ TEST_SEGMENTS_2 = SegmentList([Segment(round(a, 6), round(b, 6)) for
                                a, b in TEST_SEGMENTS])
 
 
-class SegmentsTestCase(unittest.TestCase):
-    def test_write_segments_ascii(self):
-        for ncol in [2, 4]:
-            with NamedTemporaryFile(suffix='.txt', delete=False) as f:
-                segments.write_ascii(f.name, TEST_SEGMENTS, ncol=ncol)
-                f.delete = True
-                a = SegmentList.read(f.name, gpstype=float, strict=False)
-                self.assertEqual(a, TEST_SEGMENTS_2)
+@pytest.mark.parametrize('ncol', (2, 4))
+def test_write_segments_ascii(ncol):
+    with NamedTemporaryFile(suffix='.txt', delete=False) as tmp:
+        segments.write_ascii(tmp.name, TEST_SEGMENTS, ncol=ncol)
+        tmp.delete = True
+        a = SegmentList.read(tmp.name, gpstype=float, strict=False)
+        assert a == TEST_SEGMENTS_2

--- a/hveto/tests/test_triggers.py
+++ b/hveto/tests/test_triggers.py
@@ -29,9 +29,7 @@ from gwpy.segments import (Segment, SegmentList)
 
 from glue.lal import Cache
 
-from hveto import triggers
-
-from common import unittest
+from .. import triggers
 
 AUX_FILES = {
     'L1:GDS-CALIB_STRAIN': 'L1-GDS_CALIB_STRAIN_OMICRON-12345-67890.xml.gz',
@@ -40,24 +38,24 @@ AUX_FILES = {
 }
 
 
-class TriggersTestCase(unittest.TestCase):
+def test_aux_channels_from_cache():
+    cache = list(AUX_FILES.values())
+    channels = triggers.find_auxiliary_channels(
+        'omicron', None, None, cache=cache)
+    assert channels == sorted(AUX_FILES.keys())
 
-    def test_aux_channels_from_cache(self):
-        cache = list(AUX_FILES.values())
-        channels = triggers.find_auxiliary_channels(
-            'omicron', None, None, cache=cache)
-        self.assertListEqual(channels, sorted(AUX_FILES.keys()))
-        channels = triggers.find_auxiliary_channels(
-            'omicron', None, None, cache=Cache.from_urls(cache))
-        self.assertListEqual(channels, sorted(AUX_FILES.keys()))
+    channels = triggers.find_auxiliary_channels(
+        'omicron', None, None, cache=Cache.from_urls(cache))
+    assert channels == sorted(AUX_FILES.keys())
 
-    def test_get_triggers(self):
-        # test that trigfind raises a warning if the channel-level directory
-        # doesn't exist
-        with pytest.warns(UserWarning):
-            out = triggers.get_triggers('X1:DOES_NOT_EXIST', 'omicron',
-                                        SegmentList([Segment(0, 100)]))
-        # check output type and columns
-        self.assertIsInstance(out, Table)
-        for col in ['time', 'frequency', 'snr']:
-            self.assertIn(col, out.dtype.names)
+
+def test_get_triggers():
+    # test that trigfind raises a warning if the channel-level directory
+    # doesn't exist
+    with pytest.warns(UserWarning):
+        out = triggers.get_triggers('X1:DOES_NOT_EXIST', 'omicron',
+                                    SegmentList([Segment(0, 100)]))
+    # check output type and columns
+    assert isinstance(out, Table)
+    for col in ['time', 'frequency', 'snr']:
+        assert col in out.dtype.names

--- a/hveto/tests/test_utils.py
+++ b/hveto/tests/test_utils.py
@@ -19,16 +19,15 @@
 """Tests for `hveto.utils`
 """
 
-from hveto import utils
+import pytest
 
-from common import unittest
+from .. import utils
 
 
-class UtilsTestCase(unittest.TestCase):
-    def test_channel_groups(self):
-        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 1)),
-                             [[1, 2, 3, 4, 5]])
-        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 2)),
-                             [[1, 2, 3], [4, 5]])
-        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 10)),
-                             [[1], [2], [3], [4], [5]])
+@pytest.mark.parametrize('n, out', [
+    (1, [[1, 2, 3, 4, 5]]),
+    (2, [[1, 2, 3], [4, 5]]),
+    (10, [[1], [2], [3], [4], [5]]),
+])
+def test_channel_groups(n, out):
+    assert list(utils.channel_groups([1, 2, 3, 4, 5], n)) == out

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ dqsegdb
 gwpy >= 0.12.0
 git+https://github.com/ligovirgo/gwdetchar.git
 lxml
+pytest >= 3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 test = pytest
 
-[pytest]
-addopts = --verbose -r s
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     'gwtrigfind',
 ]
 tests_require = [
-    'pytest'
+    'pytest >= 3.0.0',
     'mock ; python_version < \'3\'',
 ]
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,10 @@ else:
 
 setup_requires = [
     'setuptools',
-    'pytest-runner',
 ]
+if 'test' in sys.argv:
+    setup_requires.append('pytest-runner')
+
 install_requires = [
     'numpy',
     'matplotlib',
@@ -75,9 +77,8 @@ install_requires = [
 ]
 tests_require = [
     'pytest'
+    'mock ; python_version < \'3\'',
 ]
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
 extras_require = {
     'doc': [
         'sphinx',


### PR DESCRIPTION
This PR rewrites the `hveto.tests` suite to use `pytest` syntax, instead of `unittest` - it's easier to read and write, and is a little more flexible.