### PR TITLE
Reproduce GWPY_TEX_RCPARAMS for use with gwpy-0.13+

### DIFF
--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -34,11 +34,20 @@ from matplotlib import rcParams
 from matplotlib.colors import LogNorm
 
 from gwpy.plot import Plot
+from gwpy.plot.tex import MACROS as GWPY_TEX_MACROS
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
 
 rcParams.update({
+    # reproduce GWPY_TEX_RCPARAMS
+    'text.usetex': True,
+    'text.latex.preamble': (
+        rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
+    'font.family': ['serif'],
+    'font.size': 16,
+    'axes.formatter.use_mathtext': False,
+    # custom Hveto formatting
     'figure.subplot.bottom': 0.17,
     'figure.subplot.left': 0.12,
     'figure.subplot.right': 0.88,


### PR DESCRIPTION
This PR reproduces the `GWPY_TEX_RCPARAMS` settings so that Hveto plots are rendered with LaTeX, as before, for compatibility with gwpy-0.13+. An example plot made with these changes is attached below.

cc @duncanmmacleod, @jrsmith02 

![test_hveto](https://user-images.githubusercontent.com/5273800/52545039-1f8b6580-2d7a-11e9-9357-9fb49275b714.png)