### PR TITLE
Render HTML with Helvetica Neue for consistency with other DetChar tools

### DIFF
--- a/hveto/html.py
+++ b/hveto/html.py
@@ -49,11 +49,7 @@ FANCYBOX_CSS = (
 FANCYBOX_JS = (
     "//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js")
 
-FONT_LATO_CSS = (
-    "//fonts.googleapis.com/css?family=Lato:300,700"
-)
-
-CSS_FILES = [BOOTSTRAP_CSS, FANCYBOX_CSS, FONT_LATO_CSS]
+CSS_FILES = [BOOTSTRAP_CSS, FANCYBOX_CSS]
 JS_FILES = [JQUERY_JS, BOOTSTRAP_JS, FANCYBOX_JS]
 
 HVETO_CSS = """
@@ -63,7 +59,7 @@ html {
 }
 body {
 		margin-bottom: 120px;
-		font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		-webkit-font-smoothing: antialiased;
 }
 .footer {

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -52,8 +52,11 @@ rcParams.update({
     'figure.subplot.left': 0.12,
     'figure.subplot.right': 0.88,
     'figure.subplot.top': 0.90,
+    'xtick.labelsize': 16,
+    'ytick.labelsize': 16,
     'axes.labelsize': 24,
     'axes.labelpad': 2,
+    'axes.titlesize': 24,
     'grid.color': 'gray',
     'grid.alpha': 0.5,
 })


### PR DESCRIPTION
This PR tweaks Hveto's HTML pages to use Helvetica Neue, rather than Lato, for consistency with other DetChar tools hosted in [`gwdetchar/gwdetchar`](https://github.com/gwdetchar/gwdetchar).

Example output illustrating the difference may be found here:

IFO | UTC Date | Production Hveto | Test Hveto
---|---|---|---
L1 | 2019-02-08 | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/hveto/day/20190208/latest/) | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/hveto/day/20190208/)

cc @jrsmith02 