### PR TITLE
Select random glitches to Omega scan from each round, rather than the loudest ones

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -27,6 +27,7 @@ jobstart = time.time()
 
 import argparse
 import os
+import random
 import warnings
 import multiprocessing
 import json
@@ -575,12 +576,13 @@ cum. deadtime :   %s""" % (
                      % (round.n, tag.lower(), f))
         round.files[tag] = f
 
-    # record times for omega scans
+    # record times to omega scan
     if args.omega_scans:
-        vetoed.sort(scol)
-        round.scans = vetoed[-args.omega_scans:][::-1]
-        logger.debug("Identified %d events for omega scan\n%s"
-                     % (args.omega_scans, round.scans))
+        N = len(vetoed)
+        ind = random.sample(range(0, N), min(args.omega_scans, N))
+        round.scans = vetoed[ind]
+        logger.debug("Collected %d events to omega scan\n%s"
+                     % (len(round.scans), round.scans))
 
     # -- make some plots --
 
@@ -812,7 +814,7 @@ logger.debug("Summary JSON written to %s" % f.name)
 if args.omega_scans:
     omegatimes = list(map(str, sorted(unique(
         [t['time'] for r in rounds for t in r.scans]))))
-    logger.debug("Identified %d times for omega scan" % len(omegatimes))
+    logger.debug("Collected %d times to omega scan" % len(omegatimes))
     newtimes = [t for t in omegatimes if not
                 os.path.exists(os.path.join(omegadir, str(t)))]
     logger.debug("%d scans already complete or in progress, %d remaining"
@@ -820,7 +822,6 @@ if args.omega_scans:
     if len(newtimes) > 0:
         logger.info('Creating workflow for omega scans...')
         batch = [args.wdq_batch] + newtimes + [
-            '--wpipeline', 'gwdetchar-omega',
             '--ignore-state-flags',
             '--output-dir', omegadir,
             '--ifo', ifo,


### PR DESCRIPTION
This pull request uses the native `random.sample` utility to select a random sample of N triggers per round to omega scan, rather than the N loudest. These changes are [**python-3.7 compliant**](https://docs.python.org/3/library/random.html). Note, because of this, any two `hveto` runs with otherwise identical arguments will now generally produce omega scans of a different collection of glitch times.

Other miscellaneous changes include:

* Remove the omega scan argument `--wpipeline gwdetchar-omega`, as that is now the default (and will be deprecated in O3)
* Minor tweak to `DEBUG`-level logs so that "omega scan" is used as a verb :)

A test of these changes is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/hveto/day/20190208/), including omega scans (requires `LIGO.ORG` credentials). This test was run in a python-2.7 environment.

cc @jrsmith02, @areeda, @duncanmmacleod 