### PR TITLE
Use the brand-new gwdetchar package for omega scans

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -62,7 +62,7 @@ from hveto.segments import (write_ascii as write_ascii_segments,
 from hveto.triggers import (get_triggers, find_auxiliary_channels)
 
 IFO = os.getenv('IFO')
-WDQ_BATCH = find_executable('wdq-batch')
+WDQ_BATCH = find_executable('gwdetchar-omega-batch')
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Joshua Smith <joshua.smith@ligo.org>'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dqsegdb
 gitpython
-git+https://github.com/ligovirgo/gwdetchar.git
+gwdetchar
 gwpy >= 0.12.0
 gwtrigfind
 jinja2


### PR DESCRIPTION
We have tagged a 0.1.1 release of `gwdetchar`, so let's use that for omega scans.

cc @duncanmmacleod, @jrsmith02 