### PR TITLE
Address build test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,30 @@
 language: python
 
-python:
-  - '2.7'
-  - '3.6'
-
-env:
-  matrix:
-    - PIP_FLAGS="--quiet"
-    - PIP_FLAGS="--quiet --pre"
-
 matrix:
-  allow_failures:
-    - python: '3.6'
   fast_finish: true
+
+  include:
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.5'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.6'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+      env: PIP_FLAGS="--quiet --pre"
+
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.5'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.6'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+      env: PIP_FLAGS="--quiet"
 
 before_install:
   - python -m pip install -q --upgrade pip

--- a/bin/hveto
+++ b/bin/hveto
@@ -835,8 +835,8 @@ if args.omega_scans:
         if proc.returncode:
             raise subprocess.CalledProcessError(
                 proc.returncode, ' '.join(batch))
-        loggger.info('Launched %d omega scans to condor, ' % newtimes
-                     'check their progress with condor_q')
+        loggger.info('Launched {} omega scans to condor, check their progress '
+                     'with condor_q'.format(newtimes))
     else:
         logger.debug('Skipping omega scans')
 

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -34,19 +34,12 @@ from matplotlib import rcParams
 from matplotlib.colors import LogNorm
 
 from gwpy.plot import Plot
-from gwpy.plot.tex import MACROS as GWPY_TEX_MACROS
+from gwpy.plot.tex import (has_tex, MACROS as GWPY_TEX_MACROS)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
 
 rcParams.update({
-    # reproduce GWPY_TEX_RCPARAMS
-    'text.usetex': True,
-    'text.latex.preamble': (
-        rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
-    'font.family': ['serif'],
-    'font.size': 10,
-    'axes.formatter.use_mathtext': False,
     # custom Hveto formatting
     'figure.subplot.bottom': 0.17,
     'figure.subplot.left': 0.12,
@@ -60,6 +53,17 @@ rcParams.update({
     'grid.color': 'gray',
     'grid.alpha': 0.5,
 })
+
+if has_tex():
+    rcParams.update({
+        # reproduce GWPY_TEX_RCPARAMS
+        'text.usetex': True,
+        'text.latex.preamble': (
+            rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
+        'font.family': ['serif'],
+        'font.size': 10,
+        'axes.formatter.use_mathtext': False,
+    })
 
 SHOW_HIDE_JAVASCRIPT = """
     <script type="text/ecmascript">

--- a/hveto/tests/test_triggers.py
+++ b/hveto/tests/test_triggers.py
@@ -27,8 +27,6 @@ from astropy.table import Table
 
 from gwpy.segments import (Segment, SegmentList)
 
-from glue.lal import Cache
-
 from .. import triggers
 
 AUX_FILES = {
@@ -45,7 +43,7 @@ def test_aux_channels_from_cache():
     assert channels == sorted(AUX_FILES.keys())
 
     channels = triggers.find_auxiliary_channels(
-        'omicron', None, None, cache=Cache.from_urls(cache))
+        'omicron', None, None, cache=cache)
     assert channels == sorted(AUX_FILES.keys())
 
 

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -21,10 +21,71 @@
 
 from __future__ import division
 
+import sys
 import os.path
 from math import ceil
 
+try:  # python 3.x
+    from io import StringIO
+    from html.parser import HTMLParser
+    from html.entities import name2codepoint
+except:  # python 2.7
+    from cStringIO import StringIO
+    from HTMLParser import HTMLParser
+    from htmlentitydefs import name2codepoint
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# -- class for HTML parsing ---------------------------------------------------
+
+class HvetoHTMLParser(HTMLParser):
+    """See https://docs.python.org/3/library/html.parser.html.
+    """
+    def handle_starttag(self, tag, attrs):
+        print("Start tag:", tag)
+        attrs.sort()
+        for attr in attrs:
+            print("attr:", attr)
+
+    def handle_endtag(self, tag):
+        print("End tag:", tag)
+
+    def handle_data(self, data):
+        print("Data:", data)
+
+    def handle_comment(self, data):
+        print("Comment:", data)
+
+    def handle_entityref(self, name):
+        c = chr(name2codepoint[name])
+        print("Named entity:", c)
+
+    def handle_charref(self, name):
+        if name.startswith('x'):
+            c = chr(int(name[1:], 16))
+        else:
+            c = chr(int(name))
+        print("Numeric entity:", c)
+
+    def handle_decl(self, data):
+        print("Decl:", data)
+
+parser = HvetoHTMLParser()
+
+
+# -- utilities ----------------------------------------------------------------
+
+def parse_html(html):
+    """Parse a string containing raw HTML code
+    """
+    stdout = sys.stdout
+    sys.stdout = StringIO()
+    parser.feed(html)
+    output = sys.stdout.getvalue()
+    sys.stdout = stdout
+    return output
 
 
 def channel_groups(channellist, ngroups):


### PR DESCRIPTION
This pull request resolves a few build test failures I introduced recently:

* Use TeX only if it is available on the local system, otherwise leave it off
* We no longer use the Lato font, so the unit test for `hveto.html.init_page` needs to be updated
* Fix a formatting issue in a print statement in `bin/hveto`

Now that we are python3 compliant, I'm also adding this:

* Fix python3.6 build failures and stop allowing them to fail
* Install python3.5 and python3.7 build tests
* Take advantage of the `tmpdir` kwarg in `pytest`

cc @duncanmmacleod, @jrsmith02