### PR TITLE
Updated trigger reading to handle multiple ETGs and use HDF5 by default

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -482,7 +482,7 @@ while True:
 
     # work out the vetoes for this round
     allaux = auxiliary[winner.name][
-        auxiliary[winner.name][scol] >= winner.snr]
+        auxiliary[winner.name][auxscol] >= winner.snr]
     winner.events = allaux
     coincs = allaux[core.find_coincidences(allaux['time'], primary['time'],
                                            dt=winner.window)]

--- a/hveto/config.py
+++ b/hveto/config.py
@@ -67,7 +67,8 @@ Each of the below sections lists the valid options and a description of what the
 ``snr-threshold``      The minimum threshold on signal-to-noise ratio for
                        primary channel events to be included in the analysis
 ``frequency-range``    The `(low, high`) frequency range of interest for this
-                       analysis
+                       analysis. Note that for CBC trigger generators, the
+                       ``'template_duration'`` column is used here.
 ``read-format``        The ``format`` name to use when reading files for this
                        trigger generator
 ``read-columns``       The list of three column names equivalent to
@@ -233,14 +234,10 @@ class HvetoConfigParser(configparser.ConfigParser):
             'trigger-generator': 'Omicron',
             'snr-threshold': 8,
             'frequency-range': (30, 2048),
-            'read-format': 'ligolw',
-            'read-tablename': 'sngl_burst',
         },
         'auxiliary': {
             'trigger-generator': 'Omicron',
             'frequency-range': (30, 2048),
-            'read-format': 'ligolw',
-            'read-tablename': 'sngl_burst',
         },
         'safety': {
             'unsafe-channels': ['%(IFO)s:GDS-CALIB_STRAIN',

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -357,7 +357,7 @@ def veto_scatter(
         lim[0] *= 0.95
         lim[1] *= 1.05
         # handle logs
-        if axargs.get("yscale", "linear") == "log" and lim[0] <= 0.:
+        if axargs.get("%sscale" % axis, "linear") == "log" and lim[0] <= 0.:
             lim[0] = None
         axargs.setdefault('%slim' % axis, lim)
     _finalize_plot(plot, ax, outfile, **axargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dqsegdb
 gitpython
 gwdetchar
-gwpy >= 0.12.0
+gwpy >= 0.14.0
 gwtrigfind
 jinja2
 lscsoft-glue >= 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ if 'test' in sys.argv:
 
 install_requires = [
     'gwdetchar',  # for omega scans only
-    'gwpy >= 0.12.0',
+    'gwpy >= 0.14.0',
     'gwtrigfind',
     'lxml',
     'lscsoft-glue >= 1.60.0 ; python_version < \'3\'',


### PR DESCRIPTION
This PR updates the `hveto.triggers` module to better handle ETGs other than Omicron, and to prefer HDF5 by default for Omicron.

The results should be identical when comparing runs made with LIGO_LW XML vs HDF5. Example results (require LIGO.ORG authentication):

- [Omicron LIGO_LW XML](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/hveto/testing/hdf5/omicron-xml/)
- [Omicron HDF5](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/hveto/testing/hdf5/omicron/)
- [PyCBC Live HDF5](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/hveto/testing/hdf5/pycbc/)

