### PR TITLE
Conda environments require utf-8 encoded strings in StringIO

### DIFF
--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -82,7 +82,10 @@ def parse_html(html):
     """
     stdout = sys.stdout
     sys.stdout = StringIO()
-    parser.feed(html)
+    if sys.version_info.major < 3:
+        parser.feed(html.decode('utf-8', 'ignore'))
+    else:
+        parser.feed(html)
     output = sys.stdout.getvalue()
     sys.stdout = stdout
     return output


### PR DESCRIPTION
This patch is required to pass unit tests in conda environments with python-2.7.

cc @duncanmmacleod, @jrsmith02 