### PR TITLE
Use setup.cfg for metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,17 @@ install:
   - python -m pip install --editable .
 
 script:
-  - python -m pip install ${PIP_FLAGS} "pytest>=3.0.0" "mock ; python_version < '3'"
+  - python -m pip install ${PIP_FLAGS} \
+        "pytest>=3.0.0" \
+        "mock ; python_version < '3'" \
+        "coverage"
   - python -m coverage run -m pytest hveto/
   - python -m coverage run --append `which hveto` --help
   - python -m coverage run --append `which hveto-cache-events` --help
   - python -m coverage run --append `which hveto-trace` --help
 
 after_success:
+  - python -m pip install coveralls
   - coveralls
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ install:
   - python -m pip install --editable .
 
 script:
-  - python -m pip install ${PIP_FLAGS} unittest2 coveralls "pytest>=2.8"
-  - coverage run ./setup.py test
-  - coverage run --append `which hveto` --help
-  - coverage run --append `which hveto-cache-events` --help
-  - coverage run --append `which hveto-trace` --help
+  - python -m pip install ${PIP_FLAGS} "pytest>=3.0.0" "mock ; python_version < '3'"
+  - python -m coverage run -m pytest hveto/
+  - python -m coverage run --append `which hveto` --help
+  - python -m coverage run --append `which hveto-cache-events` --help
+  - python -m coverage run --append `which hveto-trace` --help
 
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-scripts = find:
+scripts =
+	bin/hveto
+	bin/hveto-cache-events
+	bin/hveto-trace
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 setup_requires =
 	setuptools >=30.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,14 +72,8 @@ parentdir_prefix =
 
 ; -- tools ------------------
 
-[aliases]
-test = pytest
-
 [coverage:run]
 source = hveto
 omit =
 	hveto/tests/*
 	hveto/_version.py
-
-[tool:pytest]
-addopts = --verbose -r s

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,63 @@
-[aliases]
-test = pytest
+; -- metadata ---------------
 
-[tool:pytest]
-addopts = --verbose -r s
+[metadata]
+name = hveto
+author = Joshua Smith
+author_email = joshua.smith@ligo.org
+license = GPLv3
+license_file = LICENSE
+keywords = physics, astronomy, gravitational-waves, ligo
+url = https://github.com/gwdetchar/hveto/
+description = A python implementation of the HierarchicalVeto (hveto) algorithm.
+long_description = file: README.rst
+classifiers =
+	Development Status :: 4 - Beta
+	Intended Audience :: Developers
+	Intended Audience :: End Users/Desktop
+	Intended Audience :: Science/Research
+	License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+	Natural Language :: English
+	Operating System :: POSIX
+	Operating System :: Unix
+	Operating System :: MacOS
+	Programming Language :: Python
+	Programming Language :: Python :: 2.7
+	Programming Language :: Python :: 3.5
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Topic :: Scientific/Engineering
+	Topic :: Scientific/Engineering :: Astronomy
+	Topic :: Scientific/Engineering :: Physics
+
+[options]
+zip_safe = False
+packages = find:
+scripts = find:
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+setup_requires =
+	setuptools >=30.3.0
+install_requires =
+	gwdetchar
+	gwpy >=0.14.0
+	gwtrigfind
+	jinja2
+	lscsoft-glue >=2.0.0
+	lxml
+	matplotlib >=1.5
+	numpy >=1.10
+	pykerberos
+	scipy
+tests_require =
+	pytest >=3.0.0
+	mock ; python_version < '3'
+
+[options.extras_require]
+doc =
+	sphinx
+	numpydoc
+	sphinx_rtd_theme
+	sphinxcontrib_programoutput
+	sphinxcontrib_epydoc
 
 [versioneer]
 VCS = git
@@ -12,8 +67,16 @@ versionfile_build = hveto/_version.py
 tag_prefix =
 parentdir_prefix =
 
+; -- tools ------------------
+
+[aliases]
+test = pytest
+
 [coverage:run]
 source = hveto
 omit =
 	hveto/tests/*
 	hveto/_version.py
+
+[tool:pytest]
+addopts = --verbose -r s

--- a/setup.py
+++ b/setup.py
@@ -20,33 +20,13 @@
 """Setup the Hveto package
 """
 
-from __future__ import print_function
-
-import sys
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
-
-import glob
-import os.path
-
-from setuptools import (setup, find_packages)
-
-# set basic metadata
-PACKAGENAME = 'hveto'
-DISTNAME = 'hveto'
-AUTHOR = 'Joshua Smith'
-AUTHOR_EMAIL = 'joshua.smith@ligo.org'
-LICENSE = 'GPLv3'
-
-cmdclass = {}
-
-# -- versioning ---------------------------------------------------------------
+from setuptools import setup
 
 import versioneer
-__version__ = versioneer.get_version()
-cmdclass.update(versioneer.get_cmdclass())
 
-# -- documentation ------------------------------------------------------------
+# versioneer
+version = versioneer.get_version()
+cmdclass = versioneer.get_cmdclass()
 
 # import sphinx commands
 try:
@@ -56,79 +36,9 @@ except ImportError:
 else:
     cmdclass['build_sphinx'] = BuildDoc
 
-# -- dependencies -------------------------------------------------------------
-
-setup_requires = [
-    'setuptools',
-]
-if 'test' in sys.argv:
-    setup_requires.append('pytest-runner')
-
-install_requires = [
-    'gwdetchar',  # for omega scans only
-    'gwpy >= 0.14.0',
-    'gwtrigfind',
-    'lxml',
-    'lscsoft-glue >= 1.60.0 ; python_version < \'3\'',
-    'lscsoft-glue >= 2.0.0 ; python_version > \'3\'',
-    'matplotlib',
-    'numpy',
-    'scipy',
-]
-tests_require = [
-    'pytest >= 3.0.0',
-    'mock ; python_version < \'3\'',
-]
-extras_require = {
-    'doc': [
-        'sphinx',
-        'numpydoc',
-        'sphinx_rtd_theme',
-        'sphinxcontrib_programoutput',
-        'sphinxcontrib_epydoc',
-    ],
-}
-
-# -- run setup ----------------------------------------------------------------
-
-packagenames = find_packages()
-scripts = glob.glob(os.path.join('bin', '*'))
-
-setup(name=DISTNAME,
-      provides=[PACKAGENAME],
-      version=__version__,
-      description=None,
-      long_description=None,
-      author=AUTHOR,
-      author_email=AUTHOR_EMAIL,
-      license=LICENSE,
-      packages=packagenames,
-      include_package_data=True,
-      cmdclass=cmdclass,
-      scripts=scripts,
-      setup_requires=setup_requires,
-      install_requires=install_requires,
-      tests_require=tests_require,
-      extras_require=extras_require,
-      test_suite='hveto.tests',
-      use_2to3=True,
-      classifiers=[
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Development Status :: 3 - Alpha',
-          'Intended Audience :: Science/Research',
-          'Intended Audience :: End Users/Desktop',
-          'Intended Audience :: Developers',
-          'Natural Language :: English',
-          'Topic :: Scientific/Engineering',
-          'Topic :: Scientific/Engineering :: Astronomy',
-          'Topic :: Scientific/Engineering :: Physics',
-          'Operating System :: POSIX',
-          'Operating System :: Unix',
-          'Operating System :: MacOS',
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-      ],
-      )
+# run setup
+# NOTE: all other metadata and options come from setup.cfg
+setup(
+    version=version,
+    cmdclass=cmdclass,
+)


### PR DESCRIPTION
This PR updates the build infrastructure to store all metadata in `setup.cfg`, which just makes things a bit more readable. Specifically the addition of `use_2to3 = False` should fix the bugs @alurban saw in the 0.1.0 wheels.