### PR TITLE
Added LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include versioneer.py
 include hveto/_version.py


### PR DESCRIPTION
This PR patches `MANIFEST.in` to ensure that the `LICENSE` gets included in the release tarballs.