### PR TITLE
Fix Zenodo link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ proposing additions/changes.
 
 .. |PyPI version| image:: https://badge.fury.io/py/hveto.svg
    :target: http://badge.fury.io/py/hveto
-.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/2584620.svg
-   :target: https://doi.org/10.5281/zenodo.2587020
+.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/2584615.svg
+   :target: https://doi.org/10.5281/zenodo.2584615
 .. |License| image:: https://img.shields.io/pypi/l/hveto.svg
    :target: https://choosealicense.com/licenses/gpl-3.0/
 .. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/hveto.svg


### PR DESCRIPTION
This PR corrects `README.rst` to point to the "cite-all-versions" Zenodo DOI, so that the link automatically updates to the latest released version.

cc @duncanmmacleod, @jrsmith02 