### PR TITLE
Use pygments for syntax highlighting

### DIFF
--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -63,7 +63,7 @@ HTML_INIT = """<!DOCTYPE HTML>
 
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
-<p>Page generated using <a href="https://github.com/gwdetchar/hveto/tree/%s" target="_blank">Hveto version %s</a> by {user} at {date}</p>
+<p>These results were obtained using <a href="https://github.com/gwdetchar/hveto/tree/%s" target="_blank">hveto version %s</a> by {user} at {date}.</p>
 </div>
 </footer>""" % (COMMIT, VERSION)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy >= 1.10
 pykerberos
 pytest >= 3.0.0
 scipy
+pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
 	numpy >=1.10
 	pykerberos
 	scipy
+    pygments
 tests_require =
 	pytest >=3.0.0
 	mock ; python_version < '3'


### PR DESCRIPTION
This PR switches to using the `pygments` package to render config flies with syntax highlighting, and includes minor tweaks to the HTML footer.

Note, pygments is available through both PyPI (pip install pygments) and Conda (conda install pygments) and is compatible with python-3.x.

Test hveto output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/hveto/day/20190108/about/), made within a conda environment running python-2.7.

cc @duncanmmacleod, @jrsmith02