### PR TITLE
Unit test expansion pack

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -54,9 +54,10 @@ from gwpy.time import to_gps
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 
+from gwdetchar.io.html import FancyPlot
+
 from hveto import (__version__, log, config, core, plot, html, utils)
-from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, FancyPlot,
-                        get_column_label)
+from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, get_column_label)
 from hveto.segments import (write_ascii as write_ascii_segments,
                             read_veto_definer_file)
 from hveto.triggers import (get_triggers, find_auxiliary_channels)

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -207,36 +207,6 @@ def get_column_label(column):
         return r'\texttt{{{0}}}'.format(column)
 
 
-# -- Plot construction --------------------------------------------------------
-
-class FancyPlot(object):
-    """A helpful class of objects that coalesce image links and caption text
-    for fancybox figures.
-
-    Parameters
-    ----------
-    img : `str` or `FancyPlot`
-        either a filename (including relative or absolute path) or another
-        FancyPlot instance
-    caption : `str`
-        the text to be displayed in a fancybox as this figure's caption
-
-    Examples
-    --------
-    >>> from hveto.plot import FancyPlot
-    >>> example = FancyPlot('plot.png')
-    >>> print example.img, example.caption
-    """
-    def __init__(self, img, caption=None):
-        if isinstance(img, FancyPlot):
-            caption = caption if caption else img.caption
-        self.img = str(img)
-        self.caption = caption if caption else os.path.basename(self.img)
-
-    def __str__(self):
-        return self.img
-
-
 # -- Functions ----------------------------------------------------------------
 
 def before_after_histogram(

--- a/hveto/segments.py
+++ b/hveto/segments.py
@@ -44,8 +44,10 @@ DEFAULT_SEGMENT_SERVER = os.getenv('DEFAULT_SEGMENT_SERVER',
 def integer_segments(f):
     @wraps(f)
     def decorated_method(*args, **kwargs):
-        segs = f(*args, **kwargs)
-        return type(segs)(type(s)(int(s[0]), int(s[1])) for s in segs)
+        flag = f(*args, **kwargs)
+        segs = flag.active
+        flag.active = type(segs)(type(s)(int(s[0]), int(s[1])) for s in segs)
+        return flag
     return decorated_method
 
 
@@ -74,6 +76,6 @@ def read_veto_definer_file(vetofile, start=None, end=None, ifo=None):
         tmp = urlopen(vetofile)
         vetofile = os.path.abspath(os.path.basename(vetofile))
         with open(vetofile, 'w') as f:
-            f.write(tmp.read())
+            f.write(str(tmp.read()))
     return DataQualityDict.from_veto_definer_file(
         vetofile, format='ligolw', start=start, end=end, ifo=ifo)

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -32,7 +32,6 @@ use('agg')  # nopep8
 
 from .. import html
 from .._version import get_versions
-from ..plot import FancyPlot
 from ..utils import parse_html
 
 VERSION = get_versions()['version']
@@ -132,64 +131,6 @@ def test_close_page(tmpdir):
 def test_bold_param(args, kwargs, result):
     h1 = parse_html(html.bold_param(*args, **kwargs))
     h2 = parse_html(result)
-    assert h1 == h2
-
-
-@pytest.mark.parametrize('args, kwargs, result', [
-    (('test.html', 'Test link'), {},
-     '<a href="test.html" target="_blank">Test link</a>'),
-    (('test.html', 'Test link'), {'class_': 'test-case'},
-     '<a class="test-case" href="test.html" target="_blank">Test link</a>'),
-])
-def test_html_link(args, kwargs, result):
-    h1 = parse_html(html.html_link(*args, **kwargs))
-    h2 = parse_html(result)
-    assert h1 == h2
-
-
-def test_cis_link():
-    h1 = parse_html(html.cis_link('X1:TEST-CHANNEL'))
-    h2 = parse_html(
-        '<a style="font-family: Monaco, &quot;Courier New&quot;, '
-        'monospace;" href="https://cis.ligo.org/channel/byname/'
-        'X1:TEST-CHANNEL" target="_blank" title="CIS entry for '
-        'X1:TEST-CHANNEL">X1:TEST-CHANNEL</a>'
-    )
-    assert h1 == h2
-
-
-def test_fancybox_img():
-    img = FancyPlot('test.png')
-    out = html.fancybox_img(img)
-    assert parse_html(out) == parse_html(
-        '<a class="fancybox" href="test.png" target="_blank" '
-        'data-fancybox-group="hveto-image" title="test.png">\n'
-        '<img class="img-responsive" alt="test.png" src="test.png" />'
-        '\n</a>'
-    )
-
-
-def test_scaffold_plots():
-    h1 = parse_html(html.scaffold_plots(
-        [FancyPlot('plot1.png'), FancyPlot('plot2.png')], nperrow=3))
-    h2 = parse_html(
-        '<div class="row">\n'
-        '<div class="col-sm-4">\n'
-        '<a class="fancybox" href="plot1.png" target="_blank" '
-            'data-fancybox-group="hveto-image" title="plot1.png">\n'
-        '<img class="img-responsive" alt="plot1.png" '
-            'src="plot1.png" />\n'
-        '</a>\n'
-        '</div>\n'
-        '<div class="col-sm-4">\n'
-        '<a class="fancybox" href="plot2.png" target="_blank" '
-        'data-fancybox-group="hveto-image" title="plot2.png">\n'
-        '<img class="img-responsive" alt="plot2.png" '
-            'src="plot2.png" />\n'
-        '</a>\n'
-        '</div>\n'
-        '</div>'
-    )
     assert h1 == h2
 
 

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -170,18 +170,18 @@ def test_fancybox_img():
 
 
 def test_scaffold_plots():
-    h1 = parse_html(html.scaffold_plots([FancyPlot('plot1.png'),
-                                         FancyPlot('plot2.png')]))
+    h1 = parse_html(html.scaffold_plots(
+        [FancyPlot('plot1.png'), FancyPlot('plot2.png')], nperrow=3))
     h2 = parse_html(
         '<div class="row">\n'
-        '<div class="col-sm-6">\n'
+        '<div class="col-sm-4">\n'
         '<a class="fancybox" href="plot1.png" target="_blank" '
             'data-fancybox-group="hveto-image" title="plot1.png">\n'
         '<img class="img-responsive" alt="plot1.png" '
             'src="plot1.png" />\n'
         '</a>\n'
         '</div>\n'
-        '<div class="col-sm-6">\n'
+        '<div class="col-sm-4">\n'
         '<a class="fancybox" href="plot2.png" target="_blank" '
         'data-fancybox-group="hveto-image" title="plot2.png">\n'
         '<img class="img-responsive" alt="plot2.png" '
@@ -204,7 +204,15 @@ def test_write_footer():
 
 def test_write_hveto_page(tmpdir):
     os.chdir(str(tmpdir))
-    html.write_hveto_page('L1', 0, 86400, [], [])
+    config = 'test.ini'
+    with open(config, 'w') as fobj:
+        fobj.write('[test]\nchannel = X1:TEST')
+    htmlv = {
+        'title': 'test',
+        'base': 'test',
+        'config': config,
+    }
+    html.write_hveto_page('L1', 0, 86400, [], [], **htmlv)
     shutil.rmtree(str(tmpdir), ignore_errors=True)
 
 

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -43,16 +43,3 @@ def test_drop_plot(num):
 
     with tempfile.NamedTemporaryFile(suffix='.svg') as svg:
         plot.significance_drop(svg.name, old, new)
-
-
-def test_fancy_plot():
-    # create a dummy FancyPlot instance
-    test = plot.FancyPlot('test.png')
-    assert test.img is 'test.png'
-    assert test.caption is 'test.png'
-
-    # check that its properties are unchanged when the argument
-    # to FancyPlot() is also a FancyPlot instance
-    test = plot.FancyPlot(test)
-    assert test.img is 'test.png'
-    assert test.caption is 'test.png'

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -30,11 +30,9 @@ from gwdatafind.utils import filename_metadata
 try:  # python 3.x
     from io import StringIO
     from html.parser import HTMLParser
-    from html.entities import name2codepoint
 except:  # python 2.7
     from cStringIO import StringIO
     from HTMLParser import HTMLParser
-    from htmlentitydefs import name2codepoint
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -71,20 +69,6 @@ class HvetoHTMLParser(HTMLParser):
 
     def handle_data(self, data):
         print("Data:", data)
-
-    def handle_comment(self, data):
-        print("Comment:", data)
-
-    def handle_entityref(self, name):
-        c = chr(name2codepoint[name])
-        print("Named entity:", c)
-
-    def handle_charref(self, name):
-        if name.startswith('x'):
-            c = chr(int(name[1:], 16))
-        else:
-            c = chr(int(name))
-        print("Numeric entity:", c)
 
     def handle_decl(self, data):
         print("Decl:", data)


### PR DESCRIPTION
This PR improves coverage of `hveto` unit tests:

* Import a few HTML constructor utilities from `gwdetchar`, now that they're available upstream, instead of defining new ones here
* Remove unused `HvetoHTMLParser` methods
* Expand unit tests for (and fix a bug in) `hveto.segments`
* Expanded unit tests for `hveto.html`

cc @duncanmmacleod, @jrsmith02 