### PR TITLE
Use gwdetchar.io.html for HTML construction

### DIFF
--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -27,13 +27,6 @@ from math import ceil
 
 from gwdatafind.utils import filename_metadata
 
-try:  # python 3.x
-    from io import StringIO
-    from html.parser import HTMLParser
-except:  # python 2.7
-    from cStringIO import StringIO
-    from HTMLParser import HTMLParser
-
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
@@ -53,44 +46,7 @@ def write_lal_cache(target, paths):
     return target
 
 
-# -- class for HTML parsing ---------------------------------------------------
-
-class HvetoHTMLParser(HTMLParser):
-    """See https://docs.python.org/3/library/html.parser.html.
-    """
-    def handle_starttag(self, tag, attrs):
-        print("Start tag:", tag)
-        attrs.sort()
-        for attr in attrs:
-            print("attr:", attr)
-
-    def handle_endtag(self, tag):
-        print("End tag:", tag)
-
-    def handle_data(self, data):
-        print("Data:", data)
-
-    def handle_decl(self, data):
-        print("Decl:", data)
-
-parser = HvetoHTMLParser()
-
-
 # -- utilities ----------------------------------------------------------------
-
-def parse_html(html):
-    """Parse a string containing raw HTML code
-    """
-    stdout = sys.stdout
-    sys.stdout = StringIO()
-    if sys.version_info.major < 3:
-        parser.feed(html.decode('utf-8', 'ignore'))
-    else:
-        parser.feed(html)
-    output = sys.stdout.getvalue()
-    sys.stdout = stdout
-    return output
-
 
 def channel_groups(channellist, ngroups):
     """Separate a list of channels into a number of equally-sized groups

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dqsegdb
 gitpython
-gwdetchar >= 0.3.2
+gwdetchar >= 0.4.0
 gwpy >= 0.14.0
 gwtrigfind
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ numpy >= 1.10
 pathlib ; python_version < '3'
 pytest >= 3.1.0
 scipy
-pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
 	numpy >=1.10
 	pathlib ; python_version < '3'
 	scipy
-	pygments
 tests_require =
 	pytest >=3.1.0
 	mock ; python_version < '3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 setup_requires =
 	setuptools >=30.3.0
 install_requires =
-	gwdetchar >= 0.3.2
+	gwdetchar >= 0.4.0
 	gwpy >=0.14.0
 	gwtrigfind
 	jinja2


### PR DESCRIPTION
This PR removes HTML utilities that are redundant with gwdetchar, and takes full advantage of gwdetchar-0.4.0 for basic HTML construction.

Note, the output page should have minor formatting enhancements for the user, particularly a custom footer with expanded information and mobile screen-friendly display. Test output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/hveto/day/20190325/) (requires `LIGO.ORG` credentials), I recommend looking with a mobile device as well to inspect the formatting.

This PR also makes a couple of dependency changes:
* Remove `pygments` as a dependency since everything it was used for is now done upstream
* Bump `gwdetchar` version requirement to 0.4.0, mainly so that @jrsmith02 can freely choose to merge either this or #117 first and it shouldn't make a difference

cc @duncanmmacleod, @jrsmith02 