### PR TITLE
Fix handling of event caches

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -304,6 +304,10 @@ petg = cp.get('primary', 'trigger-generator')
 psnr = cp.getfloat('primary', 'snr-threshold')
 pfreq = cp.getfloats('primary', 'frequency-range')
 preadkw = cp.getparams('primary', 'read-')
+if pcache is not None:  # auto-detect the file format
+    logger.debug('Unsetting the primary trigger file format')
+    preadkw['format'] = None
+    preadkw['path'] = 'triggers'
 ptrigfindkw = cp.getparams('primary', 'trigfind-')
 primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
                        cache=pcache, nproc=args.nproc,
@@ -349,6 +353,10 @@ logger.info("Reading triggers for aux channels...")
 counter = multiprocessing.Value('i', 0)
 
 areadkw = cp.getparams('auxiliary', 'read-')
+if acache is not None:  # auto-detect the file format
+    logger.debug('Unsetting the auxiliary trigger file format')
+    areadkw['format'] = None
+    areadkw['path'] = 'triggers'
 atrigfindkw = cp.getparams('auxiliary', 'trigfind-')
 
 def _get_aux_triggers(channel):

--- a/bin/hveto
+++ b/bin/hveto
@@ -85,11 +85,9 @@ parser.add_argument('-f', '--config-file', action='append', default=[],
                     help='path to hveto configuration file, can be given '
                          'multiple times (files read in order)')
 cli.add_nproc_option(parser, default=1)
-parser.add_argument('-p', '--primary-cache', action='append', default=[],
-                    type=abs_path,
+parser.add_argument('-p', '--primary-cache', default=None, type=abs_path,
                     help='path for cache containing primary channel files')
-parser.add_argument('-a', '--auxiliary-cache', action='append', default=[],
-                    type=abs_path,
+parser.add_argument('-a', '--auxiliary-cache', default=None, type=abs_path,
                     help='path for cache containing auxiliary channel files, '
                          'files contained must be T050017-compliant with the '
                          'channel name as the leading name parts, e.g. '
@@ -232,7 +230,7 @@ segments[analysis.name] = analysis
 pchannel = cp.get('primary', 'channel')
 
 # read auxiliary cache
-if args.auxiliary_cache:
+if args.auxiliary_cache is not None:
     acache = read_cache(args.auxiliary_cache)
 else:
     acache = None
@@ -296,7 +294,7 @@ htmlv['config'] = inifile
 # -- load primary triggers ----------------------------------------------------
 
 # read primary cache
-if args.primary_cache:
+if args.primary_cache is not None:
     pcache = read_cache(args.primary_cache)
 else:
     pcache = None
@@ -359,7 +357,7 @@ def _get_aux_triggers(channel):
     else:
         ifo, name = channel.split(':')
         match = "{}-{}".format(ifo, name.replace('-', '_'))
-        auxcache = [e for e in cache if Path(e).name.startswith(match)]
+        auxcache = [e for e in acache if Path(e).name.startswith(match)]
     # get triggers
     try:
         trigs = get_triggers(channel, auxetg, analysis.active, snr=minsnr,

--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -67,11 +67,9 @@ parser.add_argument('-f', '--config-file', action='append', default=[],
                     help='path to hveto configuration file, can be given '
                          'multiple times (files read in order)')
 cli.add_nproc_option(parser, default=1)
-parser.add_argument('-p', '--primary-cache', action='append', default=[],
-                    type=abs_path,
+parser.add_argument('-p', '--primary-cache', default=None, type=abs_path,
                     help='path for cache containing primary channel files')
-parser.add_argument('-a', '--auxiliary-cache', action='append', default=[],
-                    type=abs_path,
+parser.add_argument('-a', '--auxiliary-cache', default=None, type=abs_path,
                     help='path for cache containing auxiliary channel files, '
                          'files contained must be T050017-compliant with the '
                          'channel name as the leading name parts, e.g. '
@@ -228,7 +226,7 @@ def write_events(channel, tab, segments):
 pchannel = cp.get('primary', 'channel')
 
 # read auxiliary cache
-if args.auxiliary_cache:
+if args.auxiliary_cache is not None:
     acache = [e for c in args.auxiliary_cache for e in read_cache(str(c))]
 else:
     acache = None
@@ -281,7 +279,7 @@ logger.info("Identified %d auxiliary channels to process" % naux)
 logger.info("Reading events for primary channel...")
 
 # read primary cache
-if args.primary_cache:
+if args.primary_cache is not None:
     pcache = [e for c in args.primary_cache for e in read_cache(str(c))]
 else:
     pcache = None

--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -367,11 +367,11 @@ acache = [x for x in results if x is not None]
 aname = trigdir / '{}-HVETO_AUXILIARY_CACHE-{}-{}.lcf'.format(
     ifo, start, duration,
 )
-write_lal_cache(str(aname), [e for e in results if e is not None])
+write_lal_cache(str(aname), acache)
 logger.info('Auxiliary cache written to {}'.format(aname))
 
 # -- finish -------------------------------------------------------------------
 
 logger.info('Done, you can use these cache files in an hveto analysis by '
-            'passing the following arguments:\n --primary-cache {} '
-            '--auxiliary-cache {}'.format(pname, aname))
+            'passing the following arguments:\n\n--primary-cache {} '
+            '--auxiliary-cache {}\n'.format(pname, aname))

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -41,7 +41,7 @@ def write_lal_cache(target, paths):
     # write to file
     for path in paths:
         obs, tag, segment = filename_metadata(path)
-        print(obs[0], tag, segment[0], abs(segment), path, file=target)
+        print(obs, tag, segment[0], abs(segment), path, file=target)
 
     return target
 

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -41,7 +41,7 @@ def write_lal_cache(target, paths):
     # write to file
     for path in paths:
         obs, tag, segment = filename_metadata(path)
-        print(obs, tag, segment[0], abs(segment), path, file=target)
+        print(obs[0], tag, segment[0], abs(segment), path, file=target)
 
     return target
 


### PR DESCRIPTION
This PR implements a fix to hveto's handling of event caches:

* Since `gwpy.io.cache.read_cache` expects a single file (and not a list of files), require the user to pass only one `--primary-cache` and one `--auxiliary-cache`
* Since `hveto-cache-events` now caches triggers to HDF5 files, but (as far as I'm aware) online Omicron still writes in `ligolw` format, unset the `format` keyword argument before reading from cached trigger files so that the format can be auto-detected
* Misc. bugfixes for `hveto-cache-events`

This fixes #119.

cc @duncanmmacleod, @jrsmith02, @young-min