### PR TITLE
Use codecov to estimate coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 2
+  range: 50..100
+  round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1
+    patch:
+      default:
+        target: 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ script:
   - python -m coverage run --append `which hveto-trace` --help
 
 after_success:
-  - python -m pip install coveralls
-  - coveralls
+  - python -m pip install ${PIP_FLAGS} codecov
+  - python -m codecov --flags $(uname) python${TRAVIS_PYTHON_VERSION/./}
 
 cache:
   pip: true

--- a/README.rst
+++ b/README.rst
@@ -59,5 +59,5 @@ proposing additions/changes.
    :target: https://pypi.org/project/hveto/
 .. |Build Status| image:: https://travis-ci.org/gwdetchar/hveto.svg?branch=master
    :target: https://travis-ci.org/gwdetchar/hveto
-.. |Coverage Status| image:: https://coveralls.io/repos/github/gwdetchar/hveto/badge.svg?branch=master
-   :target: https://coveralls.io/github/gwdetchar/hveto?branch=master
+.. |Coverage Status| image:: https://codecov.io/gh/gwdetchar/hveto/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/gwdetchar/hveto


### PR DESCRIPTION
This PR updates the continuous integration build tests to use codecov for coverage estimates, since it's got more useful features than coveralls.

This is similar to gwdetchar/gwdetchar#302.

cc @duncanmmacleod, @jrsmith02 