### PR TITLE
Tweak use plot legend and significance-drop plot title

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -469,8 +469,9 @@ while True:
     #   drop
     if round.n > 1:
         png = (pngname % 'SIG_DROP').replace('.png', '.svg')
-        plot.significance_drop(png, oldsignificances, newsignificances,
-                               title=title, subtitle=subtitle)
+        plot.significance_drop(
+            png, oldsignificances, newsignificances,
+            title=' | '.join([title, subtitle]), bbox_inches='tight')
         logger.debug("Figure written to %s" % png)
         png = FancyPlot(png, caption=ROUND_CAPTION['SIG_DROP'])
         rounds[-1].plots.append(png)
@@ -601,7 +602,7 @@ cum. deadtime :   %s\n\n""" % (
     title = '%s Hveto round %d' % (ifo, round.n)
     ptitle = '%s: primary impact' % title
     atitle = '%s: auxiliary use' % title
-    subtitle = '[%d-%d] | winner: %s' % (start, end, wname)
+    subtitle = 'winner: %s [%d-%d]' % (wname, start, end)
 
     # before/after histogram
     png = pngname % 'HISTOGRAM'

--- a/bin/hveto
+++ b/bin/hveto
@@ -594,9 +594,9 @@ cum. deadtime :   %s\n\n""" % (
         wname = round.winner.name
     beforel = 'Before\n[%d]' % len(before)
     afterl = 'After\n[%d]' % len(primary)
-    vetoedl = 'Vetoed (primary)\n[%d]' % len(vetoed)
+    vetoedl = 'Vetoed\n(primary)\n[%d]' % len(vetoed)
     beforeauxl = 'All\n[%d]' % len(beforeaux)
-    usedl = 'Used (aux)\n[%d]' % len(winner.events)
+    usedl = 'Used\n(aux)\n[%d]' % len(winner.events)
     coincl = 'Coinc.\n[%d]' % len(coincs)
     title = '%s Hveto round %d' % (ifo, round.n)
     ptitle = '%s: primary impact' % title

--- a/bin/hveto
+++ b/bin/hveto
@@ -594,9 +594,9 @@ cum. deadtime :   %s\n\n""" % (
         wname = round.winner.name
     beforel = 'Before\n[%d]' % len(before)
     afterl = 'After\n[%d]' % len(primary)
-    vetoedl = 'Vetoed\n[%d]' % len(vetoed)
+    vetoedl = 'Vetoed (primary)\n[%d]' % len(vetoed)
     beforeauxl = 'All\n[%d]' % len(beforeaux)
-    usedl = 'Used\n[%d]' % len(winner.events)
+    usedl = 'Used (aux)\n[%d]' % len(winner.events)
     coincl = 'Coinc.\n[%d]' % len(coincs)
     title = '%s Hveto round %d' % (ifo, round.n)
     ptitle = '%s: primary impact' % title

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -343,6 +343,7 @@ def _finalize_plot(plot, ax, outfile, bbox_inches=None, close=True, **axargs):
     # format axes
     for key in axargs:
         getattr(ax, 'set_%s' % key)(axargs[key])
+    # format subtitle first
     if subtitle:
         pos = list(ax.title.get_position())
         pos[1] += 0.05
@@ -365,15 +366,14 @@ def _finalize_plot(plot, ax, outfile, bbox_inches=None, close=True, **axargs):
         plot.close()
 
 
-def significance_drop(outfile, old, new, show_channel_names=None,
-                      bbox_inches='tight', **kwargs):
+def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
     """Plot the signifiance drop for each channel
     """
     channels = sorted(old.keys())
     if show_channel_names is None:
         show_channel_names = len(channels) <= 50
 
-    plot = Plot(figsize=(18, 6))
+    plot = Plot(figsize=(20, 5))
     plot.subplots_adjust(left=.07, right=.93)
     ax = plot.gca()
     if show_channel_names:
@@ -452,7 +452,7 @@ def significance_drop(outfile, old, new, show_channel_names=None,
             tooltips[-1].set_gid('tooltip-%d' % i)
 
         f = BytesIO()
-        plot.savefig(f, bbox_inches=bbox_inches, format='svg')
+        plot.savefig(f, format='svg')
         tree, xmlid = etree.XMLID(f.getvalue())
         tree.set('onload', 'init(evt)')
         for i in range(len(tooltips)):
@@ -470,7 +470,7 @@ def significance_drop(outfile, old, new, show_channel_names=None,
         etree.ElementTree(tree).write(outfile)
         plot.close()
     else:
-        _finalize_plot(plot, ax, outfile, bbox_inches=bbox_inches, **kwargs)
+        _finalize_plot(plot, ax, outfile, **kwargs)
 
 
 def hveto_roc(outfile, rounds, figsize=[9, 6], constants=[1, 5, 10, 20],

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -365,7 +365,8 @@ def _finalize_plot(plot, ax, outfile, bbox_inches=None, close=True, **axargs):
         plot.close()
 
 
-def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
+def significance_drop(outfile, old, new, show_channel_names=None,
+                      bbox_inches='tight', **kwargs):
     """Plot the signifiance drop for each channel
     """
     channels = sorted(old.keys())
@@ -451,7 +452,7 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
             tooltips[-1].set_gid('tooltip-%d' % i)
 
         f = BytesIO()
-        plot.savefig(f, format='svg')
+        plot.savefig(f, bbox_inches=bbox_inches, format='svg')
         tree, xmlid = etree.XMLID(f.getvalue())
         tree.set('onload', 'init(evt)')
         for i in range(len(tooltips)):
@@ -469,7 +470,7 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
         etree.ElementTree(tree).write(outfile)
         plot.close()
     else:
-        _finalize_plot(plot, ax, outfile, **kwargs)
+        _finalize_plot(plot, ax, outfile, bbox_inches=bbox_inches, **kwargs)
 
 
 def hveto_roc(outfile, rounds, figsize=[9, 6], constants=[1, 5, 10, 20],


### PR DESCRIPTION
This PR tweaks the legend text in auxiliary use plots, and the title position in significance drop plots. Example output is available [**here**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/hveto/day/20190419/) (requires `LIGO.ORG` credentials).

This addresses a request by Sheila Dwyer in [**`ligo-summary-pages`**](https://git.ligo.org/detchar/ligo-summary-pages/issues/114).

cc @jrsmith02, @duncanmmacleod 