### PR TITLE
Bugfix for null-result hveto pages

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -325,15 +325,15 @@ if livetime == 0:
     message = ("No active segments found for analysis flag %r in interval "
                "[%d, %d)" % (aflag, start, end))
     logger.critical(message)
-    index = html.write_null_page(ifo, start, end, message, context='info',
-                                 **htmlv)
+    htmlv['context'] = 'info'
+    index = html.write_null_page(ifo, start, end, message, **htmlv)
     logger.info("HTML report written to %s" % index)
     sys.exit(0)
 
 # no primary triggers
 if len(primary) == 0:
-    index = html.write_null_page(ifo, start, end, message, context='danger',
-                                 **htmlv)
+    htmlv['context'] = 'danger'
+    index = html.write_null_page(ifo, start, end, message, **htmlv)
     logger.info("HTML report written to %s" % index)
     sys.exit(0)
 


### PR DESCRIPTION
This PR fixes an issue discovered in production, where hveto runs with null results fail on producing an output webpage due to multiple values being passed for the `context` keyword argument.

cc @jrsmith02, @duncanmmacleod 