### PR TITLE
Disable LaTeX plot rendering by default

### DIFF
--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -32,7 +32,6 @@ from matplotlib import rcParams
 from matplotlib.colors import LogNorm
 
 from gwpy.plot import Plot
-from gwpy.plot.tex import (has_tex, MACROS as GWPY_TEX_MACROS)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
@@ -51,17 +50,6 @@ rcParams.update({
     'grid.color': 'gray',
     'grid.alpha': 0.5,
 })
-
-if has_tex():
-    rcParams.update({
-        # reproduce GWPY_TEX_RCPARAMS
-        'text.usetex': True,
-        'text.latex.preamble': (
-            rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
-        'font.family': ['serif'],
-        'font.size': 10,
-        'axes.formatter.use_mathtext': False,
-    })
 
 SHOW_HIDE_JAVASCRIPT = """
     <script type="text/ecmascript">


### PR DESCRIPTION
This PR disables LaTeX plot rendering by default, as is done in gwpy. Users who wish to render plots in LaTeX may still do so by setting the environment variable:

```bash
$ export GWPY_USETEX=true
```

cc @duncanmmacleod, @jrsmith02 