### PR TITLE
Use gwdetchar.plot.texify for LaTeX escape characters

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -575,8 +575,8 @@ cum. deadtime :   %s\n\n""" % (
 
     # -- make some plots --
 
-    pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' %
-        (ifo, round.n, start, duration))
+    pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' % (
+        ifo, round.n, start, duration))
     wname = texify(round.winner.name)
     beforel = 'Before\n[%d]' % len(before)
     afterl = 'After\n[%d]' % len(primary)

--- a/bin/hveto
+++ b/bin/hveto
@@ -47,6 +47,7 @@ from gwpy.segments import (Segment, SegmentList,
 from gwdetchar import cli
 from gwdetchar.io.html import (FancyPlot, cis_link)
 from gwdetchar.omega import batch
+from gwdetchar.plot import texify
 
 from hveto import (__version__, config, core, plot, html, utils)
 from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, get_column_label)
@@ -574,12 +575,9 @@ cum. deadtime :   %s\n\n""" % (
 
     # -- make some plots --
 
-    pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' % (
-        ifo, round.n, start, duration))
-    if plot.rcParams['text.usetex']:
-        wname = round.winner.name.replace('_', r'\_')
-    else:
-        wname = round.winner.name
+    pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' %
+        (ifo, round.n, start, duration))
+    wname = texify(round.winner.name)
     beforel = 'Before\n[%d]' % len(before)
     afterl = 'After\n[%d]' % len(primary)
     vetoedl = 'Vetoed\n(primary)\n[%d]' % len(vetoed)

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -32,6 +32,8 @@ from matplotlib.colors import LogNorm
 
 from gwpy.plot import Plot
 
+from gwdetchar.plot import texify
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
 
@@ -382,8 +384,7 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
     # set xticks to show channel names
     if show_channel_names:
         ax.set_xticks(range(len(channels)))
-        ax.set_xticklabels([c.replace('_', '\_')
-                            for c in channels])  # noqa: W605
+        ax.set_xticklabels([texify(c) for c in channels])
         for i, t in enumerate(ax.get_xticklabels()):
             t.set_rotation(270)
             t.set_verticalalignment('top')
@@ -431,8 +432,8 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
                 ha = 'center'
             y = l.get_ydata()[0] + yoffset
             c = l.get_label()
-            tooltips.append(ax.annotate(c.replace('_', r'\_'), (x, y),
-                                        ha=ha, zorder=ylim[1], bbox=bbox))
+            tooltips.append(ax.annotate(texify(c), (x, y), ha=ha,
+                                        zorder=ylim[1], bbox=bbox))
             l.set_gid('line-%d' % i)
             tooltips[-1].set_gid('tooltip-%d' % i)
 


### PR DESCRIPTION
This PR utilizes the new `gwdetchar.plot.texify` utility to determine when and where to use LaTeX escape characters in plot rendering. Since `texify` is new to gwdetchar-1.0.0, this also bumps the version requirement.

Example output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/hveto/day/20190607/) (requires `LIGO.ORG` credentials).

**Note:** This PR is marked a work-in-progress and **should not be merged** until gwdetchar-1.0.0 is released.

cc @jrsmith02, @duncanmmacleod 