### PR TITLE
Add clustering to hveto executable

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -307,6 +307,13 @@ else:
        pchannel, livetime)
     logger.critical(message)
 
+# cluster primary triggers
+clusterkwargs = cp.getparams('primary', 'cluster-')
+if clusterkwargs:
+    primary = primary.cluster(**clusterkwargs)
+    logger.info("%d primary events remain after clustering over %s" %
+                (len(primary), clusterkwargs['rank']))
+
 # -- bail out early -----------------------------------------------------------
 # the bail out is done here so that we can at least generate the eventual
 # configuration file, mainly for HTML purposes


### PR DESCRIPTION
This adds the option of clustering primary triggers with `gwpy.table.EventTable.cluster()`. The arguments to this function are passed as `cluster-arg` where (currently), `cluster` expects `rank`, `index`, and `window`. 

An example config block used to cluster PyCBC triggers in a test run:
```
cluster-index = time
cluster-rank = new_snr
cluster-window = 0.1
```

The resulting log message:
```
hveto 2019-11-05 10:43:46 CST     INFO: Identified 787 auxiliary channels to process
hveto 2019-11-05 10:43:46 CST     INFO: Configuration recorded as L1-HVETO_CONFIGURATION-1240185618-6000.ini
hveto 2019-11-05 10:44:08 CST     INFO: Read 31025 events for L1:GDS-CALIB_STRAIN
hveto 2019-11-05 10:44:09 CST     INFO: 6538 primary events remain after clustering over new_snr
hveto 2019-11-05 10:44:09 CST     INFO: Reading triggers for aux channels...
hveto 2019-11-05 10:44:09 CST    DEBUG:     [1/787] Read 71 events for L1:HPI-ETMY_BLND_L4C_VP_IN1_DQ
hveto 2019-11-05 10:44:09 CST    DEBUG:     [2/787] Read 94 events for L1:HPI-HAM6_BLND_L4C_Y_IN1_DQ
```

The results: 
Unclustered (requires LIGO.org auth): https://ldas-jobs.ligo-la.caltech.edu/~thomas.massinger/detchar/CBC/test/hveto-cbc/
Clustered (requires LIGO.org auth):  https://ldas-jobs.ligo-la.caltech.edu/~thomas.massinger/detchar/CBC/test/hveto-cbc-clustered/