### PR TITLE
Fix pages with null result

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -696,8 +696,8 @@ if not rounds:
         winner.name, cis_link(winner.name, class_='alert-link'))
     message += '<br>[T<sub>win</sub>: %ss, SNR: %s]' % (
         winner.window, winner.snr)
-    index = html.write_null_page(ifo, start, end, message, context='warning',
-                                 **htmlv)
+    htmlv['context'] = 'warning'
+    index = html.write_null_page(ifo, start, end, message, **htmlv)
     logger.info("HTML report written to %s" % index)
     sys.exit(0)
 


### PR DESCRIPTION
The `context` kwarg has a set default in `htmlv`, so when `write_null_page(context='warning', **htmlv)`is invoked, the function receives two different arguments for the the `context` kwarg and an error is thrown. This was preventing the creation of results pages in the case where no round was found above the significance threshold.

This fix sets the `context` kwarg in `htmlv` and passes the kwarg dictionary as is done in other use cases (see https://github.com/gwdetchar/hveto/blob/master/bin/hveto#L319 or https://github.com/gwdetchar/hveto/blob/master/bin/hveto#L326) 