### PR TITLE
Pass ranking statistic to omega scan selection

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -414,7 +414,7 @@ auxslabel = get_column_label(auxscol)
 auxflabel = get_column_label(auxfcol)
 
 rounds = []
-round = core.HvetoRound(1, pchannel)
+round = core.HvetoRound(1, pchannel, rank=scol)
 round.segments = analysis.active
 
 while True:
@@ -674,7 +674,7 @@ cum. deadtime :   %s\n\n""" % (
 
     # move to the next round
     rounds.append(round)
-    round = core.HvetoRound(round.n + 1, pchannel,
+    round = core.HvetoRound(round.n + 1, pchannel, rank=scol,
                             segments=round.segments-round.vetoes)
 
 # write file with all segments

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -54,10 +54,11 @@ class HvetoRound(object):
         'plots',
         'files',
         'scans',
+        'rank',
     )
 
     def __init__(self, round, primary, segments=None, vetoes=None,
-                 plots=[], files={}):
+                 plots=[], files={}, rank=None):
         self.n = round
         self.primary = primary
         self.segments = segments
@@ -65,6 +66,7 @@ class HvetoRound(object):
         self.plots = []
         self.files = {}
         self.scans = None
+        self.rank = rank
 
     @property
     def livetime(self):

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -302,7 +302,7 @@ def write_round(round_, context):
         page.p('<b>Omega scans:</b>')
         for t in round_.scans:
             page.p()
-            page.a('%s [SNR %.1f]' % (t['time'], t['snr']),
+            page.a('%s [SNR %.1f]' % (t['time'], t[round_.rank]),
                    href='./scans/%s/' % t['time'], **{
                        'class_': 'fancybox',
                        'style': 'color: inherit;',


### PR DESCRIPTION
In the current code, the omega scan process looks for the `triggers['snr']` column when writing the list of omega scans for each round. This fails when you use something like PyCBC triggers, which use `new_snr` as the ranking statistic. This PR attaches the ranking statistic, denoted `scol` in `/bin/hveto`, to each round as a class attribute and then has the omega scan listing code generically invoke `triggers[round.rank]`. 

Example using Omicron (behind LIGO.org auth): https://ldas-jobs.ligo-la.caltech.edu/~thomas.massinger/hveto/test-omega/
Example using PyCBC (behind LIGO.org auth): https://ldas-jobs.ligo-la.caltech.edu/~thomas.massinger/detchar/CBC/hveto/20191104/

Note: the text still says SNR despite what the column name is listed as. This is intentional since the rest of the code base and HTML refers to the ranking statistic column as SNR when defining thresholds, etc.