### PR TITLE
Adjust plotting for PyCBC triggers

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -424,6 +424,10 @@ rounds = []
 round = core.HvetoRound(1, pchannel, rank=scol)
 round.segments = analysis.active
 
+# set plot values for PyCBC triggers
+scatter_lim = [5, 12] if petg == 'pycbc.live' else [3, 100]
+scatter_log = False if petg == 'pycbc.live' else True
+
 while True:
     logger.info("-- Processing round %d --" % round.n)
 
@@ -631,9 +635,9 @@ cum. deadtime :   %s\n\n""" % (
     plot.veto_scatter(
         png, before, vetoed, x='time', y=fcol, color=scol,
         label1=None, label2=None, ylabel=flabel,
-        clabel=slabel, clim=[3, 100], cmap='YlGnBu',
+        clabel=slabel, clim=scatter_lim, cmap='YlGnBu',
         epoch=start, xlim=[start, end], ylim=pfreq,
-        title=ptitle, subtitle=subtitle)
+        title=ptitle, subtitle=subtitle, clog=scatter_log)
     logger.debug("Figure written to %s" % png)
     png = FancyPlot(png, caption=ROUND_CAPTION['TIME'])
     round.plots.append(png)

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -179,7 +179,7 @@ COLUMN_LABEL = {
     'central_freq': r"Frequency [Hz]",
     'frequency': r"Frequency [Hz]",
     'mchirp': r"Chirp mass [M$_\odot$]",
-    'new_snr': r"$\chi^2$-weighted signal-to-noise ratio (New SNR)",
+    'new_snr': r"$\chi^2$-weighted SNR (newSNR)",
     'peak_frequency': r"Frequency [Hz]",
     'rho': r"$\rho$",
     'snr': r"Signal-to-noise ratio (SNR)",


### PR DESCRIPTION
This PR passes modified plotting parameters when the etg is listed as `pycbc.live`.  Also shortens the colorbar label for newSNR, which was long enough that it overlapped the labels on the time axis of scatter plots. If the ETG is anything other than `pycbc.live`, the default behavior of a logarithmic colorbar with limits of `[3, 100]` is passed to the plotting function.