### PR TITLE
WIP: Modular plotting

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -50,7 +50,8 @@ from gwdetchar.omega import batch
 from gwdetchar.plot import texify
 
 from hveto import (__version__, config, core, plot, html, utils)
-from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, get_column_label)
+from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, get_column_label,
+                        write_round_plots)
 from hveto.segments import (write_ascii as write_ascii_segments,
                             read_veto_definer_file)
 from hveto.triggers import (get_triggers, find_auxiliary_channels)
@@ -62,7 +63,6 @@ __credits__ = ('Joshua Smith <joshua.smith@ligo.org>, '
                'Alex Urban <alexander.urban@ligo.org>')
 
 logger = cli.logger(name=os.path.basename(__file__))
-
 
 # -- parse command line -------------------------------------------------------
 
@@ -299,6 +299,7 @@ primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
                        cache=pcache, nproc=args.nproc,
                        trigfind_kwargs=ptrigfindkw, **preadkw)
 fcol, scol = primary.dtype.names[1:3]
+cols = {'fcol': fcol, 'scol': scol}
 
 if len(primary):
     logger.info("Read %d events for %s" % (len(primary), pchannel))
@@ -415,13 +416,14 @@ pevents = [primary]
 pvetoed = []
 
 auxfcol, auxscol = auxiliary[auxchannels[0]].dtype.names[1:3]
-slabel = get_column_label(scol)
-flabel = get_column_label(fcol)
-auxslabel = get_column_label(auxscol)
-auxflabel = get_column_label(auxfcol)
+cols.update({'auxscol': auxscol, 'auxfcol': auxfcol})
+plot_labels = {'slabel': get_column_label(cols['scol']),
+               'flabel': get_column_label(cols['fcol']),
+               'auxslabel': get_column_label(cols['auxscol']),
+               'auxflabel': get_column_label(cols['auxfcol'])}
 
 rounds = []
-round = core.HvetoRound(1, pchannel, rank=scol)
+round = core.HvetoRound(1, pchannel, rank=cols['scol'])
 round.segments = analysis.active
 
 while True:
@@ -481,7 +483,7 @@ while True:
 
     # work out the vetoes for this round
     allaux = auxiliary[winner.name][
-        auxiliary[winner.name][auxscol] >= winner.snr]
+        auxiliary[winner.name][cols['auxscol']] >= winner.snr]
     winner.events = allaux
     coincs = allaux[core.find_coincidences(allaux['time'], primary['time'],
                                            dt=winner.window)]
@@ -580,108 +582,24 @@ cum. deadtime :   %s\n\n""" % (
         logger.debug("Collected %d events to omega scan:\n\n%s\n\n"
                      % (len(round.scans), round.scans))
 
-    # -- make some plots --
+    # -- make some plots and set up titles for drop plots --
 
     pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' % (
         ifo, round.n, start, duration))
     wname = texify(round.winner.name)
-    beforel = 'Before\n[%d]' % len(before)
-    afterl = 'After\n[%d]' % len(primary)
-    vetoedl = 'Vetoed\n(primary)\n[%d]' % len(vetoed)
-    beforeauxl = 'All\n[%d]' % len(beforeaux)
-    usedl = 'Used\n(aux)\n[%d]' % len(winner.events)
-    coincl = 'Coinc.\n[%d]' % len(coincs)
     title = '%s Hveto round %d' % (ifo, round.n)
-    ptitle = '%s: primary impact' % title
-    atitle = '%s: auxiliary use' % title
     subtitle = 'winner: %s [%d-%d]' % (wname, start, end)
+    # split args into plotting vs data
 
-    # before/after histogram
-    png = pngname % 'HISTOGRAM'
-    plot.before_after_histogram(
-        png, before[scol], primary[scol],
-        label1=beforel, label2=afterl, xlabel=slabel,
-        title=ptitle, subtitle=subtitle)
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['HISTOGRAM'])
-    round.plots.append(png)
 
-    # snr versus time
-    png = pngname % 'SNR_TIME'
-    plot.veto_scatter(
-        png, before, vetoed, x='time', y=scol, label1=beforel, label2=vetoedl,
-        epoch=start, xlim=[start, end], ylabel=slabel,
-        title=ptitle, subtitle=subtitle, legend_title="Primary:")
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['SNR_TIME'])
-    round.plots.append(png)
-
-    # snr versus frequency
-    png = pngname % 'SNR_%s' % fcol.upper()
-    plot.veto_scatter(
-        png, before, vetoed, x=fcol, y=scol, label1=beforel,
-        label2=vetoedl, xlabel=flabel, ylabel=slabel, xlim=pfreq,
-        title=ptitle, subtitle=subtitle, legend_title="Primary:")
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['SNR'])
-    round.plots.append(png)
-
-    # frequency versus time coloured by SNR
-    png = pngname % '%s_TIME' % fcol.upper()
-    plot.veto_scatter(
-        png, before, vetoed, x='time', y=fcol, color=scol,
-        label1=None, label2=None, ylabel=flabel,
-        clabel=slabel, clim=[3, 100], cmap='YlGnBu',
-        epoch=start, xlim=[start, end], ylim=pfreq,
-        title=ptitle, subtitle=subtitle)
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['TIME'])
-    round.plots.append(png)
-
-    # aux used versus frequency
-    png = pngname % 'USED_SNR_TIME'
-    plot.veto_scatter(
-        png, winner.events, vetoed, x='time', y=[auxscol, scol], label1=usedl,
-        label2=vetoedl, ylabel=slabel, epoch=start, xlim=[start, end],
-        title=atitle, subtitle=subtitle)
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['USED_SNR_TIME'])
-    round.plots.append(png)
-
-    # snr versus time
-    png = pngname % 'AUX_SNR_TIME'
-    plot.veto_scatter(
-        png, beforeaux, (winner.events, coincs), x='time', y=auxscol,
-        label1=beforeauxl, label2=(usedl, coincl), epoch=start,
-        xlim=[start, end], ylabel=auxslabel, title=atitle, subtitle=subtitle)
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_SNR_TIME'])
-    round.plots.append(png)
-
-    # snr versus frequency
-    png = pngname % 'AUX_SNR_FREQUENCY'
-    plot.veto_scatter(
-        png, beforeaux, (winner.events, coincs), x=auxfcol, y=auxscol,
-        label1=beforeauxl, label2=(usedl, coincl), xlabel=auxflabel,
-        ylabel=auxslabel, title=atitle, subtitle=subtitle, legend_title="Aux:")
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_SNR_FREQUENCY'])
-    round.plots.append(png)
-
-    # frequency versus time coloured by SNR
-    png = pngname % 'AUX_FREQUENCY_TIME'
-    plot.veto_scatter(
-        png, beforeaux, (winner.events, coincs), x='time', y=auxfcol,
-        color=auxscol, label1=None, label2=[None, None], ylabel=auxflabel,
-        clabel=auxslabel, clim=[3, 100], cmap='YlGnBu', epoch=start,
-        xlim=[start, end], title=atitle, subtitle=subtitle)
-    logger.debug("Figure written to %s" % png)
-    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_FREQUENCY_TIME'])
-    round.plots.append(png)
+    plots = plot.write_round_plots(before, primary, vetoed, beforeaux, winner,
+                                   coincs, ifo, round, (start, end), cols,
+                                   plot_labels, pfreq, pngname, logger=logger)
+    round.plots += plots
 
     # move to the next round
     rounds.append(round)
-    round = core.HvetoRound(round.n + 1, pchannel, rank=scol,
+    round = core.HvetoRound(round.n + 1, pchannel, rank=cols['scol'],
                             segments=round.segments-round.vetoes)
 
 # write file with all segments
@@ -720,8 +638,8 @@ png = pngname % 'HISTOGRAM'
 beforel = 'Before analysis [%d events]' % len(pevents[0])
 afterl = 'After %d rounds [%d]' % (len(pevents) - 1, len(pevents[-1]))
 plot.before_after_histogram(
-    png, pevents[0][scol], pevents[-1][scol],
-    label1=beforel, label2=afterl, xlabel=slabel,
+    png, pevents[0][cols['scol']], pevents[-1][cols['scol']],
+    label1=beforel, label2=afterl, xlabel=plot_labels['slabel'],
     title=title, subtitle=subtitle)
 png = FancyPlot(png, caption=HEADER_CAPTION['HISTOGRAM'])
 plots.append(png)
@@ -735,13 +653,13 @@ plots.append(png)
 logger.debug("Figure written to %s" % png)
 
 # frequency versus time
-png = pngname % '%s_TIME' % fcol.upper()
+png = pngname % '%s_TIME' % cols['fcol'].upper()
 labels = [str(r.n) for r in rounds]
 legtitle = 'Vetoed at\nround'
 plot.veto_scatter(
     png, pevents[0], pvetoed,
     label1='', label2=labels, title=title,
-    subtitle=subtitle, ylabel=flabel, x='time', y=fcol,
+    subtitle=subtitle, ylabel=plot_labels['flabel'], x='time', y=cols['fcol'],
     epoch=start, xlim=[start, end], legend_title=legtitle)
 png = FancyPlot(png, caption=HEADER_CAPTION['TIME'])
 plots.append(png)
@@ -751,7 +669,7 @@ logger.debug("Figure written to %s" % png)
 png = pngname % 'SNR_TIME'
 plot.veto_scatter(
     png, pevents[0], pvetoed, label1='', label2=labels, title=title,
-    subtitle=subtitle, ylabel=slabel, x='time', y=scol,
+    subtitle=subtitle, ylabel=plot_labels['slabel'], x='time', y=cols['scol'],
     epoch=start, xlim=[start, end], legend_title=legtitle)
 png = FancyPlot(png, caption=HEADER_CAPTION['SNR_TIME'])
 plots.append(png)

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -539,6 +539,10 @@ def write_round_plots(original_triggers, after_vetoing, vetoed, original_aux,
         channels
     labels : `dict`
         dictionary of plot labels for primary and auxiliary channels
+    pfreq : `tuple`
+        frequency range to plot for primary triggers
+    pngname : `str`
+        generalized plot filename that will be formatted for each plot
     logger : 'logging.Logger`, default: `None`
         if provided, log messages will be written to the provided logger,
 


### PR DESCRIPTION
This PR aims to make Hveto's plotting more modular, which is a precursor to expanding its functionality in future PRs. `EventTable` column names of interest and plot labels are each cast into dictionaries for organization. The plotting that is done for each round winner has been moved into `hveto/plot.py`, which removes roughly 100 lines of code from `bin/hveto` and improves readability.

WIP: Will be adding a function at the end to create summary plots in `hveto/plot.py` as well