### PR TITLE
primary_vetoed function

### DIFF
--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -20,14 +20,9 @@
 """
 
 from math import ceil
-
 from gwdatafind.utils import filename_metadata
 import pandas as pd
-import numpy
 from gwpy.time import from_gps, to_gps
-from gwpy.segments import Segment
-import argparse
-import time
 import glob
 import os
 import datetime as dt

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -100,7 +100,6 @@ def primary_vetoed(starttime, endtime, ifo, snr=6.0, significance=5.0,
     dfwhole = pd.DataFrame()
     for j in dates_final:
         hveto_path = '/home/detchar/public_html/hveto/day/' + j + '/latest/'
-    #files = glob.glob(hveto_path+'triggers/'+ '/*VETOED*.txt')
 
         try:
             files = glob.glob(hveto_path+'triggers/' + '/*VETOED*.txt')

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -21,7 +21,7 @@
 
 from math import ceil
 from gwdatafind.utils import filename_metadata
-import pandas as pd
+import pandas
 from gwpy.time import from_gps
 import glob
 import os

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -22,7 +22,7 @@
 from math import ceil
 from gwdatafind.utils import filename_metadata
 import pandas as pd
-from gwpy.time import from_gps, to_gps
+from gwpy.time import from_gps
 import glob
 import os
 import datetime as dt
@@ -86,12 +86,12 @@ def primary_vetoed(starttime, endtime, ifo, snr=6.0, significance=5.0,
     enddate = from_gps(endtime).date()
 
     filename = output_dir+'hveto_primary_{}_{}.csv'.format(starttime, endtime)
-    #Getting all the dates in string format
+    # Getting all the dates in string format
     delta = enddate - startdate
     days = delta.days
     dates_final = [(startdate + dt.timedelta(i)).strftime('%Y%m%d') for i in
                    range(days)]
-    #Getting the Vetoed triggers files for each day
+    # Getting the Vetoed triggers files for each day
     dfwhole = pd.DataFrame()
     for j in dates_final:
         hveto_path = '/home/detchar/public_html/hveto/day/' + j + '/latest/'

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -25,7 +25,7 @@ import pandas
 from gwpy.time import from_gps
 import glob
 import os
-import datetime as dt
+import datetime
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'


### PR DESCRIPTION
Added a function **primary_vetoed** to the script **hveto/utils.py.** This will fetch, given a start time and end time, all the vetoed primary triggers (gpstime, snr, peak frequency) along with the information of which auxiliary channel vetoed them and the hveto significance.