### PR TITLE
Support python-3.8 and drop python-3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,24 @@
 language: python
 
+os: linux
+
 matrix:
   fast_finish: true
 
   include:
-    - python: '3.5'
-      env: PIP_FLAGS="--quiet --pre"
-    - python: '3.6'
-      env: PIP_FLAGS="--quiet --pre"
-    - python: '3.7'
-      dist: xenial
-      sudo: required
-      env: PIP_FLAGS="--quiet --pre"
+    # conda builds
+    - name: "conda:3.6"
+      env: PYTHON_VERSION="3.6"
+    - name: "conda:3.7"
+      env: PYTHON_VERSION="3.7"
+    - name: "conda:3.8"
+      env: PYTHON_VERSION="3.8"
 
-    - python: '3.5'
-      env: PIP_FLAGS="--quiet"
-    - python: '3.6'
-      env: PIP_FLAGS="--quiet"
-    - python: '3.7'
-      dist: xenial
-      sudo: required
-      env: PIP_FLAGS="--quiet"
-
-before_install:
-  - python -m pip install -q --upgrade pip
-  - python -m pip install ${PIP_FLAGS} -r requirements.txt
 
 install:
+  # install miniconda, create env, and activate
+  - bash -ex ./ci/install-conda.sh
+  # install this package
   # note: need --editable for coverage with `which ...` to work
   - python -m pip install --editable .
 
@@ -39,8 +31,7 @@ script:
   - python -m coverage run --append `which hveto-trace` --help
 
 after_success:
-  - python -m pip install ${PIP_FLAGS} codecov
-  - python -m codecov --flags $(uname) python${TRAVIS_PYTHON_VERSION/./}
+  - bash -ex ./ci/codecov.sh
 
 cache:
   pip: true

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright (C) Duncan Macleod (2019-2020)
+#
+# This file is part of Hveto.
+#
+# Hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+set -ex
+trap 'set +ex' RETURN
+
+#
+# Submit coverage data to codecov.io
+#
+
+# reactivate environmennt
+if [ -n ${CIRCLECI} ] && [ -d /opt/conda/envs ]; then
+    conda activate hvetoci || source activate hvetoci
+fi
+
+# get path to python
+PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
+PYTHON=$(which "python${PYTHON_VERSION}")
+
+# install codecov
+${PYTHON} -m pip install ${PIP_FLAGS} coverage codecov
+
+# submit coverage results
+${PYTHON} -m codecov --flags $(uname) python${PYTHON_VERSION/./}

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright (C) Duncan Macleod (2018-2020)
+#
+# This file is part of Hveto.
+#
+# Hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# Install Hveto and dependencies using Conda
+#
+
+# install miniconda
+if ! which conda 1> /dev/null; then
+    if test ! -f ${HOME}/miniconda/etc/profile.d/conda.sh; then
+        # install conda
+        [ "$(uname)" == "Darwin" ] && MC_OSNAME="MacOSX" || MC_OSNAME="Linux"
+        MINICONDA="Miniconda${PYTHON_VERSION%%.*}-latest-${MC_OSNAME}-x86_64.sh"
+        curl -L https://repo.continuum.io/miniconda/${MINICONDA} -o miniconda.sh
+        bash miniconda.sh -b -u -p ${HOME}/miniconda
+    fi
+    source ${HOME}/miniconda/etc/profile.d/conda.sh
+fi
+hash -r
+
+# get CONDA base path
+CONDA_PATH=$(conda info --base)
+
+# configure miniconda
+conda config --set always_yes yes --set changeps1 no
+conda config --add channels conda-forge
+conda update --quiet --yes conda
+conda info --all
+
+# create environment for tests (if needed)
+if [ ! -f ${CONDA_PATH}/envs/hvetoci/conda-meta/history ]; then
+    conda create --name hvetoci python=${PYTHON_VERSION} pip setuptools
+fi
+
+# install conda dependencies (based on pip requirements file)
+conda run --name hvetoci \
+python ./ci/parse-conda-requirements.py requirements.txt -o conda-reqs.txt
+conda install --name hvetoci --quiet --yes --file conda-reqs.txt --update-all
+rm -f conda-reqs.txt  # clean up
+
+# activate the environment
+. ${CONDA_PATH}/etc/profile.d/conda.sh
+conda activate hvetoci

--- a/ci/parse-conda-requirements.py
+++ b/ci/parse-conda-requirements.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+"""Parse a requirements.txt-format file for use with Conda
+"""
+
+import argparse
+import atexit
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from distutils.spawn import find_executable
+
+import pkg_resources
+
+CONDA_PACKAGE_MAP = {
+    "matplotlib": "matplotlib-base",
+}
+
+
+def parse_requirements(file):
+    for line in file:
+        if line.startswith("-r "):
+            name = line[3:].rstrip()
+            with open(name, "r") as file2:
+                yield from parse_requirements(file2)
+        else:
+            yield from pkg_resources.parse_requirements(line)
+
+
+CONDA = find_executable("conda") or os.environ.get("CONDA_EXE", "conda")
+
+VERSION_OPERATOR = re.compile('[><=!]')
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('filename', help='path of requirments file to parse')
+parser.add_argument('-p', '--python-version',
+                    default='{0.major}.{0.minor}'.format(sys.version_info),
+                    help='python version to use (default: %(default)s)')
+parser.add_argument('-o', '--output', help='path of output file, '
+                                           'defaults to stdout')
+args = parser.parse_args()
+
+requirements = ["python={0.python_version}.*".format(args)]
+with open(args.filename, "r") as reqf:
+    for item in parse_requirements(reqf):
+        # if environment markers don't pass, skip
+        if item.marker and not item.marker.evaluate():
+            continue
+        # if requirement is a URL, skip
+        if item.url:
+            continue
+        name = CONDA_PACKAGE_MAP.get(item.name, item.name)
+        requirements.append('{}{}'.format(name, item.specifier))
+
+tmp = tempfile.mktemp()
+
+# clean up when we're done
+def _clean():
+    if os.path.isfile(tmp):
+        os.remove(tmp)
+atexit.register(_clean)
+
+# print requirements to temp file
+with open(tmp, 'w') as reqfile:
+    for req in requirements:
+        print(req, file=reqfile)
+
+# find all packages with conda
+cmd = [CONDA, 'install', '--quiet', '--dry-run', '--file', tmp, '--json']
+pfind = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+out, err = pfind.communicate()
+
+# conda search failed, which means one or more packages are missing
+if pfind.returncode:
+    if isinstance(out, bytes):
+        out = out.decode('utf-8')
+    try:
+        missing = [pkg.split('[', 1)[0].lower() for
+                   pkg in json.loads(out)['packages']]
+    except json.JSONDecodeError:
+        # run it all again so that it fails out in the open
+        subprocess.check_call(cmd)
+        raise
+    requirements = [
+        req for req in requirements if
+        VERSION_OPERATOR.split(req)[0].strip().lower() not in missing]
+
+# print output to file or stdout
+if args.output:
+    fout = open(args.output, 'w')
+else:
+    fout = sys.stdout
+try:
+    for req in requirements:
+        print(req, file=fout)
+finally:
+    fout.close()

--- a/hveto/tests/test_segments.py
+++ b/hveto/tests/test_segments.py
@@ -22,10 +22,10 @@
 import os
 import shutil
 from tempfile import NamedTemporaryFile
+from unittest import mock
 
 import pytest
 
-from gwpy.testing.compat import mock
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ scipy
 flake8
 pytest >= 3.1.0
 coverage
+# extras
+python-ligo-lw >= 1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,10 @@ classifiers =
 	Operating System :: Unix
 	Operating System :: MacOS
 	Programming Language :: Python
-	Programming Language :: Python :: 3.5
+	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
 	Topic :: Scientific/Engineering
 	Topic :: Scientific/Engineering :: Astronomy
 	Topic :: Scientific/Engineering :: Physics
@@ -35,7 +36,7 @@ scripts =
 	bin/hveto
 	bin/hveto-cache-events
 	bin/hveto-trace
-python_requires = >=3.5.0
+python_requires = >=3.6
 setup_requires =
 	setuptools >=30.3.0
 install_requires =


### PR DESCRIPTION
This PR adds support for python-3.8 and drops support for python-3.5, including:

* Improved Travis CI builds with Conda on a Linux platform
* Remove imports from the deprecated `gwpy.testing.compat` module

This fixes #140 and #133.

cc @duncanmmacleod, @jrsmith02 