### PR TITLE
Take advantage of changes introduced in gwdetchar-2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,12 @@ install:
   - travis_retry conda install --quiet --yes --update-all --name hvetoci --file conda-reqs.txt
   # clean up
   - rm -f conda-reqs.txt parse-conda-requirements.py
-  # install this version
-  - python -m pip install .
 
 script:
   # run flake8
   - python -m flake8 .
   # run test suite
-  - python -m coverage run -m pytest --pyargs hveto
+  - python -m coverage run -m pytest --verbose --pyargs hveto
   # test executables
   - python -m coverage run --append --source hveto -m hveto --help
   - python -m coverage run --append --source hveto -m hveto.cli.cache_events --help

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -57,7 +57,11 @@ from hveto import plot  # noqa: E402
 
 IFO = os.getenv('IFO')
 JOBSTART = time.time()
-LOGGER = cli.logger(name='hveto')
+
+# set up logger
+PROG = ('python -m hveto' if sys.argv[0].endswith('.py')
+        else os.path.basename(sys.argv[0]))
+LOGGER = cli.logger(name=PROG.split('python -m ').pop())
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = ('Joshua Smith <joshua.smith@ligo.org>, '
@@ -125,6 +129,7 @@ def create_parser():
     """Create a command-line parser for this entry point
     """
     parser = cli.create_parser(
+        prog=PROG,
         description=__doc__,
         version=__version__,
     )

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -250,6 +250,7 @@ def main(args=None):
     htmlv = {
         'title': '%s Hveto | %d-%d' % (ifo, start, end),
         'config': None,
+        'prog': PROG,
         'context': ifo.lower(),
     }
 

--- a/hveto/cli/cache_events.py
+++ b/hveto/cli/cache_events.py
@@ -22,7 +22,7 @@ This method will apply the minimal SNR thresholds and any frequency cuts
 as given in the configuration files
 """
 
-import h4py
+import h5py
 import os
 import multiprocessing
 import sys

--- a/hveto/cli/cache_events.py
+++ b/hveto/cli/cache_events.py
@@ -57,7 +57,10 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 IFO = os.getenv('IFO')
 
-LOGGER = cli.logger(name='hveto.cache_events')
+# set up logger
+PROG = ('python -m hveto.cache_events' if sys.argv[0].endswith('.py')
+        else os.path.basename(sys.argv[0]))
+LOGGER = cli.logger(name=PROG.split('python -m ').pop())
 
 
 # -- parse command line -------------------------------------------------------
@@ -70,6 +73,7 @@ def create_parser():
     """Create a command-line parser for this entry point
     """
     parser = cli.create_parser(
+        prog=PROG,
         description=__doc__,
         version=__version__,
     )

--- a/hveto/cli/cache_events.py
+++ b/hveto/cli/cache_events.py
@@ -22,12 +22,13 @@ This method will apply the minimal SNR thresholds and any frequency cuts
 as given in the configuration files
 """
 
+import h4py
 import os
-import warnings
 import multiprocessing
-from pathlib import Path
+import sys
+import warnings
 
-import h5py
+from pathlib import Path
 
 from astropy.table import vstack
 

--- a/hveto/cli/cache_events.py
+++ b/hveto/cli/cache_events.py
@@ -59,7 +59,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 IFO = os.getenv('IFO')
 
 # set up logger
-PROG = ('python -m hveto.cache_events' if sys.argv[0].endswith('.py')
+PROG = ('python -m hveto.cli.cache_events' if sys.argv[0].endswith('.py')
         else os.path.basename(sys.argv[0]))
 LOGGER = cli.logger(name=PROG.split('python -m ').pop())
 

--- a/hveto/cli/trace.py
+++ b/hveto/cli/trace.py
@@ -31,7 +31,7 @@ from .. import __version__
 
 __author__ = 'Joshua Smith <joshua.smith@ligo.org>'
 
-PROG = ('python -m hveto.trace' if sys.argv[0].endswith('.py')
+PROG = ('python -m hveto.cli.trace' if sys.argv[0].endswith('.py')
         else os.path.basename(sys.argv[0]))
 
 

--- a/hveto/cli/trace.py
+++ b/hveto/cli/trace.py
@@ -31,6 +31,9 @@ from .. import __version__
 
 __author__ = 'Joshua Smith <joshua.smith@ligo.org>'
 
+PROG = ('python -m hveto.trace' if sys.argv[0].endswith('.py')
+        else os.path.basename(sys.argv[0]))
+
 
 # -- parse command line -------------------------------------------------------
 
@@ -42,6 +45,7 @@ def create_parser():
     """Create a command-line parser for this entry point
     """
     parser = cli.create_parser(
+        prog=PROG,
         description=__doc__,
         version=__version__,
     )
@@ -80,7 +84,8 @@ def main(args=None):
     args = parser.parse_args(args=args)
     directory = args.directory
 
-    logger = cli.logger(name='hveto.trace', level=args.loglevel)
+    logger = cli.logger(name=PROG.split('python -m ').pop(),
+                        level=args.loglevel)
     logger.debug('Running in verbose mode')
     logger.debug('Search directory: %s' % directory)
 

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -435,4 +435,4 @@ def write_about_page(configfile, prog=None):
     index : `str`
         the path of the HTML written for this analysis
     """
-    return gwhtml.about_this_page(configfile, prog=pro, prog=prog)
+    return gwhtml.about_this_page(configfile, prog=prog)

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -121,10 +121,11 @@ def wrap_html(func):
         else:
             iargs = initargs.copy()
             aboutdir = os.path.join(outdir, 'about')
+            prog = kwargs.pop('prog', None)
             if iargs['base'] == os.path.curdir:
                 iargs['base'] = os.path.pardir
-            about = write_about_page(ifo, start, end, config, outdir=aboutdir,
-                                     **iargs)
+            about = write_about_page(
+                ifo, start, end, config, prog=prog, outdir=aboutdir, **iargs)
             if os.path.basename(about) == 'index.html':
                 about = about[:-10]
         # open page
@@ -410,7 +411,7 @@ def write_null_page(reason, context='info'):
 
 
 @wrap_html
-def write_about_page(configfile):
+def write_about_page(configfile, prog=None):
     """Write a page explaining how an hveto analysis was completed
 
     Parameters
@@ -423,6 +424,9 @@ def write_about_page(configfile):
         the GPS end time of the analysis
     configfile : `str`
         the path of the configuration file to embed
+    prog : `str`, optional
+         name of the program which produced this page, defaults to
+         the script run on the command-line
     outdir : `str`, optional
         the output directory for the HTML
 
@@ -431,4 +435,4 @@ def write_about_page(configfile):
     index : `str`
         the path of the HTML written for this analysis
     """
-    return gwhtml.about_this_page(configfile)
+    return gwhtml.about_this_page(configfile, prog=pro, prog=prog)

--- a/hveto/tests/test_segments.py
+++ b/hveto/tests/test_segments.py
@@ -20,11 +20,10 @@
 """
 
 import os
-import shutil
-from tempfile import NamedTemporaryFile
-from unittest import mock
-
 import pytest
+import shutil
+
+from unittest import mock
 
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
@@ -57,12 +56,14 @@ def test_query(dqflag):
 
 
 @pytest.mark.parametrize('ncol', (2, 4))
-def test_write_segments_ascii(ncol):
-    with NamedTemporaryFile(suffix='.txt', delete=False) as tmp:
-        segments.write_ascii(tmp.name, TEST_SEGMENTS, ncol=ncol)
-        tmp.delete = True
-        a = SegmentList.read(tmp.name, gpstype=float, strict=False)
-        assert a == TEST_SEGMENTS_2
+def test_write_segments_ascii(ncol, tmpdir):
+    outdir = str(tmpdir)
+    out = os.path.join(outdir, 'test.txt')
+    segments.write_ascii(out, TEST_SEGMENTS, ncol=ncol)
+    a = SegmentList.read(out, gpstype=float, strict=False)
+    assert a == TEST_SEGMENTS_2
+    # clean up
+    shutil.rmtree(outdir, ignore_errors=True)
 
 
 def test_write_segments_ascii_failure():

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -224,7 +224,7 @@ def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
 
 
 def _sanitize_name(name):
-    return re.sub("[-_\.]", "_", name).lower()  # noqa: W605
+    return re.sub(r"[-_\.]", "_", name).lower()
 
 
 def _format_params(channel, etg, fmt, trigfind_kwargs, read_kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # development
-gwdetchar >= 1.1.0
+gwdetchar >= 2.0.0
 gwpy >= 2.0.0
 gwtrigfind
 lxml
@@ -9,6 +9,6 @@ numpy >= 1.10
 python-ligo-lw >= 1.5.0
 scipy
 # testing
+coverage
 flake8
 pytest >= 3.1.0
-coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ python_requires = >=3.6
 setup_requires =
 	setuptools >=30.3.0
 install_requires =
-	gwdetchar >= 1.1.0
+	gwdetchar >= 2.0.0
 	gwpy >=2.0.0
 	gwtrigfind
 	lxml
@@ -58,9 +58,9 @@ install_requires =
 	python-ligo-lw >= 1.5.0
 	scipy
 tests_require =
+	coverage
 	flake8
 	pytest >=3.1.0
-	coverage
 
 [options.entry_points]
 console_scripts =
@@ -78,7 +78,7 @@ doc =
 
 [tool:pytest]
 ; print skip reasons
-addopts = --verbose -r s
+addopts = -r s
 
 ; -- tools ------------------
 


### PR DESCRIPTION
This PR bumps the version requirement of gwdetchar to 2.0.0 and implements a number of small enhancements, including:

* Discover the program name (e.g., `hveto` vs. `python -m hveto`) based on command-line usage and propagate it to the help documentation, logger, and 'About' page
* Prefer the pytest `tmpdir` fixture over `tempfile.NamedTemporaryFile`, for consistency with the rest of the software stack
* Resolve build-and-test warnings
* Drop a redundant pip install from the Travis CI configuration
* Alphabetize module imports

@jrsmith02, this does not introduce any functional changes, I'm putting through a point release so that this goes out to the LDAS grid at the same time as new versions of gwdetchar+gwsumm.