### PR TITLE
Deal with valid xml files with no trigger

### DIFF
--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -115,6 +115,7 @@ def _get_aux_triggers(channel):
         else:  # everything is fine
             LOGGER.warning("    %s No events found for %s"
                            % (tag, channel))
+            out = None
     return out
 
 

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -900,7 +900,7 @@ def main(args=None):
                 ignore_state_flags=True)
             condorcmds = batch.get_condor_arguments(
                 timeout=4,
-                extra_commands=["request_disk='1G'"],
+                extra_commands=["request_disk=1G"],
                 gps=start)
             batch.generate_dag(
                 newtimes,

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -23,7 +23,6 @@ import itertools
 from math import (log, exp, log10)
 from bisect import (bisect_left, bisect_right)
 
-import json
 import numpy
 
 from scipy.special import (gammainc, gammaln)

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -23,6 +23,7 @@ import itertools
 from math import (log, exp, log10)
 from bisect import (bisect_left, bisect_right)
 
+import json
 import numpy
 
 from scipy.special import (gammainc, gammaln)


### PR DESCRIPTION
This situation caused an error when trying to merge trigger files because data type cannot be identified without any entries in the table.