### PR TITLE
Add 'extra times' feature

### DIFF
--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -195,6 +195,16 @@ def create_parser():
         default=os.curdir,
         help='path of output directory, default: %(default)s',
     )
+    parser.add_argument(
+        '-e',
+        '--extra-times',
+        action='append',
+        default=[],
+        type=float,
+        help=('extra times to add to the list of primary triggers '
+              'to include specific times that may not meet the thresholds '
+              'used to find triggers'),
+    )
 
     # return the parser
     return parser
@@ -411,6 +421,7 @@ def main(args=None):
     ptrigfindkw = cp.getparams('primary', 'trigfind-')
     primary = get_triggers(pchannel, petg, analysis.active, snr=psnr,
                            frange=pfreq, cache=pcache, nproc=args.nproc,
+                           extra_times=args.extra_times,
                            trigfind_kwargs=ptrigfindkw, **preadkw)
     fcol, scol = primary.dtype.names[1:3]
 

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -313,9 +313,13 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
     table = table[keep]
 
     if extra_times:
+        f_low = min(table[fcolumn])
+        s_low = min(table[scolumn])
         for time in extra_times:
             extra_row = numpy.zeros(len(table.colnames))
             extra_row[0] = time
+            extra_row[1] = f_low
+            extra_row[2] = s_low
             table.add_row(extra_row)
 
     # return basic table if 'raw'

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -253,7 +253,8 @@ def _format_params(channel, etg, fmt, trigfind_kwargs, read_kwargs):
 
 
 def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
-                 raw=False, trigfind_kwargs={}, **read_kwargs):
+                 raw=False, extra_times=None, trigfind_kwargs={}, 
+                 **read_kwargs):
     """Get triggers for the given channel
     """
     etg = _sanitize_name(etg)
@@ -310,6 +311,12 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
         keep &= table[fcolumn] >= frange[0]
         keep &= table[fcolumn] < frange[1]
     table = table[keep]
+
+    if extra_times:
+        for time in extra_times:
+            extra_row = numpy.zeros(len(table.colnames))
+            extra_row[0] = time
+            table.add_row(extra_row)
 
     # return basic table if 'raw'
     if raw:


### PR DESCRIPTION
This PR adds support for specifying additional times that are added to the list of primary triggers. This feature can be used if there is a specific time of interest, such as the merger time of a GW event, that might not correspond to a trigger that passes the configured thresholds. 

An example run of Hveto with this new feature can be found here: https://ldas-jobs.ligo-wa.caltech.edu/~derek.davis/detchar/preO4/dqr_tests/hveto/