### PR TITLE
change colorbar args for matplotlib 3.5.0

### DIFF
--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -262,10 +262,11 @@ def veto_scatter(outfile, a, b, label1='All', label2='Vetoed', x='time',
     else:
         colorargs = {'edgecolor': 'none'}
         if clim:
-            colorargs['vmin'] = clim[0]
-            colorargs['vmax'] = clim[1]
             if clog:
                 colorargs['norm'] = LogNorm(vmin=clim[0], vmax=clim[1])
+            else:
+                colorargs['vmin'] = clim[0]
+                colorargs['vmax'] = clim[1]
         a = a.copy()
         a.sort(color)
         m = ax.scatter(a[x], a[ya], c=a[color], label=label1, **colorargs)


### PR DESCRIPTION
This MR addresses a comparability issue with `matplotlib>3.5.0`. This version removes support for setting both vlim/xmax and norm at the same time. This has been deprecated since `matplotlib=3.3`.  I have not yet tested this update with `3.1.0` or `3.2.0`. 

Since this just addresses compatibility issues, this MR should lead to no change in the code outputs. 