### PR TITLE
Fix bug in auto-detecting file format

### DIFF
--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -420,7 +420,6 @@ def main(args=None):
     if pcache is not None:  # auto-detect the file format
         LOGGER.debug('Unsetting the primary trigger file format')
         preadkw['format'] = None
-        preadkw['path'] = 'triggers'
     ptrigfindkw = cp.getparams('primary', 'trigfind-')
     primary = get_triggers(pchannel, petg, analysis.active, snr=psnr,
                            frange=pfreq, cache=pcache, nproc=args.nproc,
@@ -479,7 +478,6 @@ def main(args=None):
     if acache is not None:  # auto-detect the file format
         LOGGER.debug('Unsetting the auxiliary trigger file format')
         areadkw['format'] = None
-        areadkw['path'] = 'triggers'
     atrigfindkw = cp.getparams('auxiliary', 'trigfind-')
 
     # map with multiprocessing

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -33,6 +33,7 @@ import gwtrigfind
 
 from gwpy.io import cache as io_cache
 from gwpy.io.utils import file_list
+from gwpy.io.registry import get_read_format
 from gwpy.table import EventTable
 from gwpy.table.filters import in_segmentlist
 from gwpy.table.io.pycbc import filter_empty_files as filter_empty_pycbc_files
@@ -263,6 +264,9 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
         readfmt = read_kwargs.pop("format", DEFAULT_FORMAT[etg])
     except KeyError:
         raise ValueError("unsupported ETG {!r}".format(etg))
+    if not readfmt and cache:
+        # try to identify format from files in cache
+        readfmt = get_read_format(EventTable, cache[0], {}, {})
     trigfind_kwargs, read_kwargs = _format_params(
         channel,
         etg,


### PR DESCRIPTION
This PR fixes a bug in hveto that prevents users from providing cache files that do not contain `hdf5` files. Currently, if the user provides a cache file, the argument `path='triggers'` is added to the list of read arguments. However, this argument is only valid for cases with the file type `hdf5`. This PR changes things so that if the user provides a cache file, the file type is now auto-detected. If the file type is `hdf5`, then the  argument `path='triggers'` will be re-added to the list of read arguments. 