### PR TITLE
Fix reading of channels wit empty trigger filesHtml changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /hveto.egg-info
 /.eggs/
 
+# IDE
+/.idea/
+
 # documentation products
 /docs/_build/
 /docs/_generated/

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -42,6 +42,7 @@ from gwpy.table import EventTable
 from gwdetchar import cli
 from gwdetchar.io.html import (FancyPlot, cis_link)
 from gwdetchar.omega import batch
+from gwpy.time import tconvert
 
 from hveto import (__version__, config, core, html, utils)
 from hveto.segments import (write_ascii as write_ascii_segments,
@@ -233,9 +234,9 @@ def main(args=None):
 
     # log startup
     LOGGER.info("-- Welcome to Hveto --")
-    LOGGER.info("GPS start time: %d" % start)
-    LOGGER.info("GPS end time: %d" % end)
-    LOGGER.info("Interferometer: %s" % ifo)
+    LOGGER.info(f"GPS start time: {start} - {tconvert(start)}")
+    LOGGER.info(f"GPS end time: {end} - {tconvert(end)}")
+    LOGGER.info(f"Interferometer: {ifo}")
 
     # -- initialisation -------------------------
 
@@ -261,7 +262,7 @@ def main(args=None):
 
     # prepare html variables
     htmlv = {
-        'title': '%s Hveto | %d-%d' % (ifo, start, end),
+        'title': f'{ifo} Hveto | {start} - {end}',
         'config': None,
         'prog': PROG,
         'context': ifo.lower(),

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -20,11 +20,13 @@
 """
 
 import os.path
+from datetime import timedelta
 from functools import wraps
 
 from MarkupPy import markup
 
 from gwdetchar.io import html as gwhtml
+from gwpy.time import tconvert
 
 from ._version import get_versions
 
@@ -87,7 +89,7 @@ def banner(ifo, start, end):
     # write banner
     page.div(class_='page-header', role='banner')
     page.h1("%s HierarchicalVeto" % ifo, class_='pb-2 mt-3 mb-2 border-bottom')
-    page.h3("%d-%d" % (start, end), class_='mt-3')
+    page.h3(f"{start} - {end} {tconvert(start)} - {tconvert(end)}" % (start, end), class_='mt-3')
     page.div.close()
     return page()
 
@@ -101,8 +103,9 @@ def wrap_html(func):
     @wraps(func)
     def decorated_func(ifo, start, end, *args, **kwargs):
         # set page init args
+        td = timedelta(seconds=(end-start))
         initargs = {
-            'title': '%s Hveto | %d-%d' % (ifo, start, end),
+            'title': f'{ifo} Hveto | {start} - {end} ({end-start}) {tconvert(start)} - {tconvert(end)} {td}',
             'base': os.path.curdir,
         }
         for key in ['title', 'base']:

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -89,7 +89,8 @@ def banner(ifo, start, end):
     # write banner
     page.div(class_='page-header', role='banner')
     page.h1("%s HierarchicalVeto" % ifo, class_='pb-2 mt-3 mb-2 border-bottom')
-    page.h3(f"{start} - {end} {tconvert(start)} - {tconvert(end)}" % (start, end), class_='mt-3')
+    td = timedelta(seconds=(end-start))
+    page.h3(f"{start} - {end} {tconvert(start)} - {tconvert(end)}" , class_='mt-3')
     page.div.close()
     return page()
 

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -303,10 +303,11 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
                 else:
                     pass    # place for a breakpoint
 
-            new.meta = {k: new.meta[k] for k in TABLE_META if new.meta.get(k)}
-            if outofbounds:
-                new = new[in_segmentlist(new[new.dtype.names[0]], segaslist)]
-            tables.append(new)
+            if new is not None and  len(new) > 0:
+                new.meta = {k: new.meta[k] for k in TABLE_META if new.meta.get(k)}
+                if outofbounds:
+                    new = new[in_segmentlist(new[new.dtype.names[0]], segaslist)]
+                tables.append(new)
     if len(tables):
         table = vstack_tables(tables)
     else:


### PR DESCRIPTION
Omicron can create a trigger file for a time interval that has no triggers. It was decided that keeping these files added information:
- We processed the interval so it's not a gap
- Trigger rate calculations for that channel will be more accurate

The problem is that the astropy tables under gwpy's EventTable cannot merge these empty files with non-empty files beczuse it cannot determine data types.