### PR TITLE
Reinstate --help sanity check for entry points in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,10 +92,13 @@ jobs:
       run: conda list --name test
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --cov hveto --pyargs hveto.tests --cov-report=xml --junitxml=pytest.xml
+      run: python -m pytest -ra --color yes --cov hveto --pyargs hveto.tests --junitxml=pytest.xml
 
     - name: Coverage report
       run: python -m coverage report --show-missing
+
+    - name: Prepare codecov upload
+      run: python -m coverage xml
 
     - name: Publish coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,12 @@ jobs:
     - name: Run test suite
       run: python -m pytest -ra --color yes --cov hveto --pyargs hveto.tests --junitxml=pytest.xml
 
+    - name: Sanity check entry points
+      run: |
+        python -m coverage run --append --source hveto -m hveto --help
+        python -m coverage run --append --source hveto -m hveto.cli.cache_events --help
+        python -m coverage run --append --source hveto -m hveto.cli.trace --help
+
     - name: Coverage report
       run: python -m coverage report --show-missing
 


### PR DESCRIPTION
This PR reinstates the `<> --help` entry point sanity check to the CI pipeline. This was (inadvertently) removed in #164.