### PR TITLE
Vanilla universe

### DIFF
--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -194,9 +194,8 @@ def create_parser():
         action='store_true',
         help=(
             'When omega scans are requested, do not submit DAG. '
-            'Used when hveto is run in condor vanilla universe',
+            'Used when hveto is run in condor vanilla universe'),
         )
-    )
 
     # output options
     pout = parser.add_argument_group('Output options')

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -189,9 +189,13 @@ def create_parser():
               'this will launch automatically to condor, '
               'requires the gwdetchar package'),
     )
-    parser.add_argument('--no-submit', action='store_true',
-                        help='When omega scans are requested, do not submit DAG. Used when hveto is run in condor '
-                             'vanilla universe')
+    parser.add_argument(
+        '--no-submit',
+        action='store_true',
+        help=(
+            'When omega scans are requested, do not submit DAG. '
+            'Used when hveto is run in condor vanilla universe',
+        )
 
     # output options
     pout = parser.add_argument_group('Output options')

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -189,6 +189,9 @@ def create_parser():
               'this will launch automatically to condor, '
               'requires the gwdetchar package'),
     )
+    parser.add_argument('--no-submit', action='store_true',
+                        help='When omega scans are requested, do not submit DAG. Used when hveto is run in condor '
+                             'vanilla universe')
 
     # output options
     pout = parser.add_argument_group('Output options')
@@ -924,10 +927,11 @@ def main(args=None):
                 timeout=4,
                 extra_commands=["request_disk=1G"],
                 gps=start)
+            do_submit = True if args.no_submit else False
             batch.generate_dag(
                 newtimes,
                 flags=flags,
-                submit=True,
+                submit=do_submit,
                 outdir=omegadir,
                 condor_commands=condorcmds)
             LOGGER.info('Launched {} omega scans to condor'.format(

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -931,7 +931,7 @@ def main(args=None):
                 timeout=4,
                 extra_commands=["request_disk=1G"],
                 gps=start)
-            do_submit = True if args.no_submit else False
+            do_submit = not args.no_submit
             batch.generate_dag(
                 newtimes,
                 flags=flags,

--- a/hveto/__main__.py
+++ b/hveto/__main__.py
@@ -196,6 +196,7 @@ def create_parser():
             'When omega scans are requested, do not submit DAG. '
             'Used when hveto is run in condor vanilla universe',
         )
+    )
 
     # output options
     pout = parser.add_argument_group('Output options')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dynamic = [
   "version",
 ]
 
-[project.optional-depend  encies]
+[project.optional-dependencies]
 # test suite
 test = [
   "coverage[toml]",
@@ -67,7 +67,7 @@ test = [
 # sphinx documentation
 docs = [
   "numpydoc",
-  "Sphinx >=1.8",
+  "Sphinx",
   "sphinx_bootstrap_theme",
   "sphinxcontrib-programoutput",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dynamic = [
   "version",
 ]
 
-[project.optional-dependencies]
+[project.optional-depend  encies]
 # test suite
 test = [
   "coverage[toml]",


### PR DESCRIPTION
Add a command line `--no-submit option which can be combined with --omega-scans option to create the omega batch DAG submit file.

This is needed when hveto is run in the vanilla universe because the [sub]DAG cannot be submitted from an EP.

The weekly run will create a DAG to deal with this. 3 time daily runs will do the same eventually but will continue to work in the local universe.

The real work will be in the ligo-monitors project .