### PR TITLE
Add support for SNAX triggers

### DIFF
--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -48,6 +48,7 @@ DEFAULT_FORMAT = {
     "pycbc_live": "hdf5.pycbc_live",
     "kleinewelle": "ligolw",
     "dmt_omega": "ligolw",
+    "snax": "hdf5.snax",
 }
 
 DEFAULT_TRIGFIND_OPTIONS = {
@@ -66,6 +67,9 @@ DEFAULT_TRIGFIND_OPTIONS = {
     },
     ("omicron", "root.omicron"): {
         "ext": "root",
+    },
+    ("snax", "hdf5"): {
+        "ext": "h5",
     }
 }
 
@@ -88,6 +92,9 @@ DEFAULT_READ_OPTIONS = {
         "extended_metadata": False,
         "loudest": True,
         "columns": ["end_time", "template_duration", "new_snr"],
+    },
+    ("snax", "hdf5.snax"): {
+        "columns": ["time", "frequency", "snr"],
     },
 }
 
@@ -248,6 +255,8 @@ def _format_params(channel, etg, fmt, trigfind_kwargs, read_kwargs):
     # custom params for ETGs
     if etg == "pycbc_live":
         read_kwargs.setdefault("ifo", channel.split(":", 1)[0])
+    if etg == "snax":
+        read_kwargs.setdefault("channels", channel)
 
     return trigfind_kwargs, read_kwargs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ requires-python = ">=3.9"
 dependencies = [
   "gwdetchar >= 2.0.0",
   "gwpy >=2.0.0",
-  "gwtrigfind",
+  "gwtrigfind >= 0.8.3",
   "h5py",
   "lxml",
   "MarkupPy >=1.14",


### PR DESCRIPTION
This PR adds support for using SNAX triggers inside of `hveto`. This PR is dependent on https://git.ligo.org/detchar/tools/gwtrigfind/-/merge_requests/44 in `gwtrigfind`. 

An example config is as follows: 
```
[DEFAULT]
ifo = H1

[hveto]
snr-thresholds = 7.75, 8.00, 8.50, 9.00, 10.00, 11.00, 12.00, 15.00, 20.00, 40.00, 100.00, 300.00
time-windows = 0.10, 0.20, 0.40, 0.80, 1.00
minimum-significance = 3.0

[segments]
url = https://segments.ligo.org
(ll_HVeto) [derek.davis@ldas-pcdev1 Feb12_snax]$ head config.ini -n50
[DEFAULT]
ifo = H1

[hveto]
snr-thresholds = 7.75, 8.00, 8.50, 9.00, 10.00, 11.00, 12.00, 15.00, 20.00, 40.00, 100.00, 300.00
time-windows = 0.10, 0.20, 0.40, 0.80, 1.00
minimum-significance = 3.0

[segments]
url = https://segments.ligo.org
analysis-flag = %(IFO)s:DMT-ANALYSIS_READY:1
padding = 0, -10

[primary]
channel = %(IFO)s:CAL-DELTAL_EXTERNAL_DQ_0_2048
trigger-generator = snax
snr-threshold = 6.0
frequency-range = 10,1000
read-format = hdf5.snax

[auxiliary]
trigger-generator = snax
frequency-range = 10,1000
read-format = hdf5.snax
channels = H1:ASC-AS_A_DC_NSUM_OUT_DQ_0_1024
  H1:ASC-AS_A_DC_PIT_OUT_DQ_0_1024
  H1:ASC-AS_A_DC_YAW_OUT_DQ_0_1024
  H1:ASC-AS_A_RF36_I_PIT_OUT_DQ_0_1024
  H1:ASC-AS_A_RF36_I_YAW_OUT_DQ_0_1024
  H1:ASC-AS_A_RF36_Q_PIT_OUT_DQ_0_1024
  H1:ASC-AS_A_RF36_Q_YAW_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_I_PIT_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_I_SUM_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_I_YAW_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_Q_PIT_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_Q_SUM_OUT_DQ_0_1024
  H1:ASC-AS_A_RF72_Q_YAW_OUT_DQ_0_1024
  ```

This runs with the following command: `python -m hveto 1423180818 1423183818 --ifo H1 --config-file config.ini `

Tagging @jrsmith02 